### PR TITLE
fix: Parse title including owner

### DIFF
--- a/.github/workflows/calver.yml
+++ b/.github/workflows/calver.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    name: 'Auto approve publishing CalVer releases'
+    name: "Auto approve publishing CalVer releases"
     if: >-
       contains(github.event.issue.title, 'sentry') ||
       contains(github.event.issue.title, 'snuba') ||
@@ -21,7 +21,7 @@ jobs:
             const today = new Date();
             const allowedVersionPrefix = `${today.getFullYear().toString().slice(2)}.${today.getMonth()+1}.`;
             const {owner, repo} = context.repo;
-            const titleParser = /^publish: (?<repo>[^\/@]+)@(?<version>[\w.]+)$/;
+            const titleParser = /^publish: (?:getsentry\/)?(?<repo>[^\/@]+)@(?<version>[\w.]+)$/;
 
             const titleMatch = context.payload.issue.title.match(titleParser);
             if (!titleMatch) {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/github-script@v3
         with:
           script: |
-            const titleParser = /^publish: (?<owner>[^\/]+)\/(?<repo>[^@]+)@(?<version>[\w.]+)$/;
+            const titleParser = /^publish: (?:getsentry\/)?(?<repo>[^@]+)@(?<version>[\w.]+)$/;
             const titleMatch = context.payload.issue.title.match(titleParser).groups;
             const dry_run = context.payload.issue.labels.some(l => l.name === 'dry-run') ? '1' : '';
             return {dry_run, ...titleMatch};


### PR DESCRIPTION
In https://github.com/getsentry/action-prepare-release/pull/4, we unintentionally changed the format of the issue title. 

- Before: `publish: <repo>@<version>`
- After: `publish: <owner>/<repo>@<version>`

This is because the `GITHUB_REPOSITORY` env variable includes the full owner and repo name. There is also an `GITHUB_REPOSITORY_OWNER` variable, but none that only contains the repo name. This means we have two options:

1. In the prepare action, remove the owner from the repo. 
2. In the publish action, assume there's an _optional_ owner. 

In this PR, I'm going with option 2, ~~although it is not backwards compatible. This means we will have to change all existing actions before attempting the next release.~~