### PR TITLE
feat(publish): Remove accepted tag on fail

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,13 +89,13 @@ jobs:
               run_id: context.runId,
             })).data;
             const issue_number = context.payload.issue.number;
-            Promise.all(
-              await github.issues.createComment({
+            await Promise.all(
+              github.issues.createComment({
                 ...repoInfo,
                 issue_number,
                 body: `Failed to publish: [run#${context.runId}](${workflowInfo.html_url})\n\n_Bad branch? You can [delete with ease](https://github.com/${process.env.TARGET_REPO}/branches/all?query=${encodeURIComponent(process.env.RELEASE_VERSION)}) and start over._`,
               }),
-              await github.issues.removeLabel({
+              github.issues.removeLabel({
                 ...repoInfo,
                 issue_number,
                 name: 'accepted',


### PR DESCRIPTION
Right now, when a publish action fails, one needs to remove and reapply the `accepted` label to retry. This is both weird and high-friction. This patch removes the `accepted` label when a publish run fails.
