### PR TITLE
feat: Add ability to publish to selected targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
             const targetsMatch = context.payload.issue.body.match(targetsParser);
             let targets;
             if (targetsMatch) {
-              const targetMatcher = /^ - \[ \] ([\w.\[\]-]+)$/gm;
+              const targetMatcher = /^ *- \[ \] ([\w.\[\]-]+)$/gm;
               targets = Array.from(targetsMatch[1].matchAll(targetMatcher)).map(x => x[1]);
             }
 


### PR DESCRIPTION
Builds on getsentry/craft#192 to limit targets to publish to. In a follow up, we'll add updating this list automatically on failure for idempotent retries on this repo.
