### PR TITLE
ref(logging): Add CRAFT_LOG_LEVEL setting through secrets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
             exec craft publish ${{ fromJSON(steps.inputs.outputs.result).version }};
             "
         env:
+          CRAFT_LOG_LEVEL: ${{ secrets.CRAFT_LOG_LEVEL }}
           CRAFT_DRY_RUN: ${{ fromJSON(steps.inputs.outputs.result).dry_run }}
           GIT_COMMITTER_NAME: getsentry-bot
           GIT_AUTHOR_NAME: getsentry-bot


### PR DESCRIPTION
We set this to `Debug` now. See also: getsentry/craft#251.
