### PR TITLE
ref(publish): Remove ZEUS_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,8 +63,6 @@ jobs:
           GIT_AUTHOR_NAME: getsentry-bot
           EMAIL: bot@getsentry.com
           GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
-          # TODO(byk): Drop ZEUS_API_TOKEN when all repos use GitHub Artifacts
-          ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           CRAFT_GCS_TARGET_CREDS_JSON: ${{ secrets.CRAFT_GCS_TARGET_CREDS_JSON }}
           CRAFT_GCS_STORE_CREDS_JSON: ${{ secrets.CRAFT_GCS_STORE_CREDS_JSON }}


### PR DESCRIPTION
According to [this search](https://github.com/search?l=YAML&p=1&q=org%3Agetsentry+zeus&type=Code) there are no projects that use Zeus _and_ this repo. We can also remove Zeus support from Craft after this.
