### PR TITLE
fix(craft): Fix broken state saving on fail

### DIFF
--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -79,7 +79,9 @@ describe.each([false, true])("state file exists: %s", (stateFileExists) => {
     await fail(failArgs);
     expect(fs.existsSync).toHaveBeenCalledTimes(1);
     // This is process.env.GITHUB_WORKSPACE + / filename
-    expect(fs.existsSync).toHaveBeenCalledWith("./.craft-publish-21.3.1.json");
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      "./__repo__/.craft-publish-21.3.1.json",
+    );
   });
 
   test("create comment", async () => {

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -12,7 +12,7 @@ exports.default = async function fail({context, github, inputs}) {
   ).data;
   const issue_number = context.payload.issue.number;
 
-  const CRAFT_STATE_FILE_PATH = `${process.env.GITHUB_WORKSPACE}/.craft-publish-${version}.json`;
+  const CRAFT_STATE_FILE_PATH = `${process.env.GITHUB_WORKSPACE}/__repo__/.craft-publish-${version}.json`;
   let updateIssueBodyRequest;
   if (fs.existsSync(CRAFT_STATE_FILE_PATH)) {
     const issueRequest = github.issues.get({


### PR DESCRIPTION
Fix up to #334 where we changed the main working path for the repo and Craft
