### PR TITLE
fix(publish): Turns out we need to use the Job ID

### DIFF
--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -31,7 +31,7 @@ const failArgs = deepFreeze({
     actions: {
       getWorkflowRun: async () => ({
         data: {
-          html_url: "https://github.com/getsentry/sentry/actions/runs/1234",
+          html_url: "https://github.com/getsentry/sentry/runs/1234",
         },
       }),
     },
@@ -91,7 +91,7 @@ describe.each([false, true])("state file exists: %s", (stateFileExists) => {
       repo: "publish",
       issue_number: "211",
       body:
-        "Failed to publish. ([error logs](https://github.com/getsentry/sentry/actions/runs/1234?check_suite_focus=true#step:8))\n\n_Bad branch? You can [delete with ease](https://github.com/getsentry/sentry/branches/all?query=21.3.1) and start over._",
+        "Failed to publish. ([error logs](https://github.com/getsentry/sentry/runs/1234?check_suite_focus=true#step:8))\n\n_Bad branch? You can [delete with ease](https://github.com/getsentry/sentry/branches/all?query=21.3.1) and start over._",
     });
   });
 

--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -29,7 +29,7 @@ const failArgs = deepFreeze({
   },
   github: {
     actions: {
-      getWorkflowRun: async () => ({
+      getJobForWorkflowRun: async () => ({
         data: {
           html_url: "https://github.com/getsentry/sentry/runs/1234",
         },

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -4,10 +4,11 @@ exports.default = async function fail({context, github, inputs}) {
   const {repo, version} = inputs;
 
   const repoInfo = context.repo;
+  await github.actions.get;
   const workflowInfo = (
-    await github.actions.getWorkflowRun({
+    await github.actions.getJobForWorkflowRun({
       ...repoInfo,
-      run_id: context.runId,
+      job_id: context.job_id,
     })
   ).data;
   const issue_number = context.payload.issue.number;


### PR DESCRIPTION
Follow up to #367. See https://docs.github.com/en/rest/reference/actions#get-a-job-for-a-workflow-run
