### PR TITLE
Revert "fix(publish): Turns out we need to use the Job ID"

### DIFF
--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -29,9 +29,9 @@ const failArgs = deepFreeze({
   },
   github: {
     actions: {
-      getJobForWorkflowRun: async () => ({
+      getWorkflowRun: async () => ({
         data: {
-          html_url: "https://github.com/getsentry/sentry/runs/1234",
+          html_url: "https://github.com/getsentry/sentry/actions/runs/1234",
         },
       }),
     },
@@ -91,7 +91,7 @@ describe.each([false, true])("state file exists: %s", (stateFileExists) => {
       repo: "publish",
       issue_number: "211",
       body:
-        "Failed to publish. ([error logs](https://github.com/getsentry/sentry/runs/1234?check_suite_focus=true#step:8))\n\n_Bad branch? You can [delete with ease](https://github.com/getsentry/sentry/branches/all?query=21.3.1) and start over._",
+        "Failed to publish. ([error logs](https://github.com/getsentry/sentry/actions/runs/1234?check_suite_focus=true#step:8))\n\n_Bad branch? You can [delete with ease](https://github.com/getsentry/sentry/branches/all?query=21.3.1) and start over._",
     });
   });
 

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -4,11 +4,10 @@ exports.default = async function fail({context, github, inputs}) {
   const {repo, version} = inputs;
 
   const repoInfo = context.repo;
-  await github.actions.get;
   const workflowInfo = (
-    await github.actions.getJobForWorkflowRun({
+    await github.actions.getWorkflowRun({
       ...repoInfo,
-      job_id: context.job_id,
+      run_id: context.runId,
     })
   ).data;
   const issue_number = context.payload.issue.number;


### PR DESCRIPTION
Reverts getsentry/publish#372

@jan-auer [reported on Slack](https://sentry.slack.com/archives/C01C205FUAE/p1623406421001400):

>@BYK looks like there's a small issue when reporting a failed publish:
>https://github.com/getsentry/publish/runs/2801793195?check_suite_focus=true#step:9:15