### PR TITLE
fix: pin craft to 031aad308fd2a4f1b96f82dd8f881456bd8fea44

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,10 @@ jobs:
           '[{($source[]): true }] | add | {"published": (. // {}) }'
           > __repo__/.craft-publish-${{ fromJSON(steps.inputs.outputs.result).version }}.json
 
-      - uses: docker://getsentry/craft:latest
+        # due to a regression in craft c978bf605d7b4a3a6c297659e4a55f91b7a869f4 we need to pick
+        # a version lower than that.  Future craft releases currently create corrupted github
+        # artifacts.
+      - uses: docker://getsentry/craft:031aad308fd2a4f1b96f82dd8f881456bd8fea44
         name: Publish using Craft
         with:
           entrypoint: /bin/bash


### PR DESCRIPTION
Newer craft releases upload broken release artifacts to github.