### PR TITLE
chore: track crash fail rate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,14 +19,17 @@ jobs:
           script: |
             const inputs = require(`${process.env.GITHUB_WORKSPACE}/.__publish__/src/publish/inputs.js`).default;
             return await inputs({context});
-            
+
       - name: "Inform start"
         if: steps.inputs.outcome == 'success'
         uses: actions/github-script@v3
+        env:
+          PUBLISH_ARGS: ${{ steps.inputs.outputs.result }}
         with:
           script: |
+            const inputs = JSON.parse(process.env.PUBLISH_ARGS);
             const start = require(`${process.env.GITHUB_WORKSPACE}/.__publish__/src/publish/start.js`).default;
-            return await start({context, github});
+            return await start({context, github, inputs});
 
       - uses: actions/checkout@v2
         name: Check out target repo
@@ -91,7 +94,10 @@ jobs:
       - name: Close on success
         if: ${{ success() }}
         uses: actions/github-script@v3
+        env:
+          PUBLISH_ARGS: ${{ steps.inputs.outputs.result }}
         with:
           script: |
+            const inputs = JSON.parse(process.env.PUBLISH_ARGS);
             const success = require(`${process.env.GITHUB_WORKSPACE}/.__publish__/src/publish/success.js`).default;
-            return await success({context, github});
+            return await success({context, github, inputs});

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "resolutions": {
     "set-value": ">=4.0.1"
+  },
+  "dependencies": {
+    "@sentry/node": "^6.17.4"
   }
 }

--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -1,4 +1,9 @@
 jest.mock("fs");
+jest.mock("../../sentry", () => ({
+  initSentry: jest.fn(() => {}),
+  captureFailedSession: jest.fn(() => {}),
+  captureSuccessfulSession: jest.fn(() => {}),
+}));
 
 const fs = require("fs");
 const fail = require("../fail.js").default;

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
+const sentry = require("../sentry");
 
 exports.default = async function fail({context, github, inputs}) {
+  sentry.initSentry({ inputs });
   const {repo, version} = inputs;
 
   const repoInfo = context.repo;
@@ -83,4 +85,6 @@ exports.default = async function fail({context, github, inputs}) {
       name: "accepted",
     }),
   ]);
+
+  sentry.captureFailedSession({ context, inputs });
 };

--- a/src/publish/start.js
+++ b/src/publish/start.js
@@ -1,4 +1,8 @@
-exports.default = async function start({context, github}) {
+const sentry = require("../sentry");
+
+exports.default = async function start({ context, github, inputs }) {
+  sentry.initSentry({ inputs });
+
   const repoInfo = context.repo;
   const workflowInfo = (
     await github.actions.getWorkflowRun({

--- a/src/publish/success.js
+++ b/src/publish/success.js
@@ -1,4 +1,8 @@
-exports.default = async function success({context, github}) {
+const sentry = require("../sentry");
+
+exports.default = async function success({ context, github }) {
+  sentry.initSentry({ inputs });
+
   const repoInfo = context.repo;
   const workflowInfo = (
     await github.actions.getWorkflowRun({
@@ -20,4 +24,6 @@ exports.default = async function success({context, github}) {
       state: "closed",
     }),
   ]);
+
+  sentry.captureSuccessfulSession();
 };

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -1,0 +1,31 @@
+const Sentry = require("@sentry/node");
+
+function initSentry({ inputs }) {
+  const config = {
+    dsn: "TBD",
+    release: `${inputs.repo}@${inputs.version}`,
+    tracesSampleRate: 1.0,
+    autoSessionTracking: false,
+  };
+
+  Sentry.init(config);
+}
+
+function captureFailedSession({ context, inputs }) {
+  const session = Sentry.getCurrentHub().startSession({ status: "crashed" });
+  Sentry.getCurrentHub().endSession(session);
+  Sentry.setTag("repository", inputs.repo);
+  Sentry.addBreadcrumb({
+    message: "Release context",
+    category: Sentry.Severity.Log,
+    data: { issue_number: context.payload.issue.number, inputs },
+  });
+  Sentry.captureMessage(`Release failed: ${inputs.repo}`);
+}
+
+function captureSuccessfulSession() {
+  const session = Sentry.getCurrentHub().startSession({ status: "ok" });
+  Sentry.getCurrentHub().endSession(session);
+}
+
+module.exports = { initSentry, captureFailedSession, captureSuccessfulSession };

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -2,7 +2,7 @@ const Sentry = require("@sentry/node");
 
 function initSentry({ inputs }) {
   const config = {
-    dsn: "TBD",
+    dsn: "https://303a687befb64dc2b40ce4c96de507c5@o1.ingest.sentry.io/6183838",
     release: `${inputs.repo}@${inputs.version}`,
     tracesSampleRate: 1.0,
     autoSessionTracking: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,6 +483,74 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@sentry/core@6.17.4":
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.17.4.tgz#ac23c2a9896b27fe4c532c2013c58c01f39adcdb"
+  integrity sha512-7QFgw+I9YK/X1Gie0c7phwT5pHMow66UCXHzDzHR2aK/0X3Lhn8OWlcGjIt5zmiBK/LHwNfQBNMskbktbYHgdA==
+  dependencies:
+    "@sentry/hub" "6.17.4"
+    "@sentry/minimal" "6.17.4"
+    "@sentry/types" "6.17.4"
+    "@sentry/utils" "6.17.4"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.17.4":
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.17.4.tgz#af4f5f745340d676be023dc3038690b557111f4d"
+  integrity sha512-6+EvPcrPCwUmayeieIpm1ZrRNWriqMHWZFyw+MzunFLgG8IH8G45cJU1zNnTY9Jwwg4sFIS9xrHy3AOkctnIGw==
+  dependencies:
+    "@sentry/types" "6.17.4"
+    "@sentry/utils" "6.17.4"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.17.4":
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.17.4.tgz#6a35dbdb22a1c532d1eb7b4c0d9223618cb67ccd"
+  integrity sha512-p1A8UTtRt7bhV4ygu7yDNCannFr9E9dmqgeZWC7HrrTfygcnhNRFvTXTj92wEb0bFKuZr67wPSKnoXlkqkGxsw==
+  dependencies:
+    "@sentry/hub" "6.17.4"
+    "@sentry/types" "6.17.4"
+    tslib "^1.9.3"
+
+"@sentry/node@^6.17.4":
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.17.4.tgz#1207530e9d84c049ffffe070bc2bb8eba47bf21b"
+  integrity sha512-LpC07HsobBiFrNLe16ubgHGw95+7+3fEBhSn58r48j68c4Qak3fDmpR1Uy0rhyX1Nr/WFdlE/4npkgJw+1lN/w==
+  dependencies:
+    "@sentry/core" "6.17.4"
+    "@sentry/hub" "6.17.4"
+    "@sentry/tracing" "6.17.4"
+    "@sentry/types" "6.17.4"
+    "@sentry/utils" "6.17.4"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/tracing@6.17.4":
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.17.4.tgz#17c2ab50d9e4cdf727b9b25e7f91ae3a9ea19437"
+  integrity sha512-UV6wWH/fqndts0k0cptsNtzD0h8KXqHInJSCGqlWDlygFRO16jwMKv0wfXgqsgc3cBGDlsl8C4l6COSwz9ROdg==
+  dependencies:
+    "@sentry/hub" "6.17.4"
+    "@sentry/minimal" "6.17.4"
+    "@sentry/types" "6.17.4"
+    "@sentry/utils" "6.17.4"
+    tslib "^1.9.3"
+
+"@sentry/types@6.17.4":
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.17.4.tgz#36b78d7c4a6de19b2bbc631bb34893bcad30c0ba"
+  integrity sha512-RUyiXCKf61k2GIMP7FQX0naoSew4zLxe+UrtbjwVcWU4AFPZfH7tLNtTpVE85zAKbxsaiq3OD2FPtTZarHcwxQ==
+
+"@sentry/utils@6.17.4":
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.17.4.tgz#4f109629d2e7f16c5595b4367445ef47bfe96b61"
+  integrity sha512-+ENzZbrlVL1JJ+FoK2EOS27nbA/yToeaJPFlyVOnbthUxVyN3TTi9Uzn9F05fIE/2BTkOEk89wPtgcHafgrD6A==
+  dependencies:
+    "@sentry/types" "6.17.4"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -615,6 +683,13 @@ acorn@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.1.tgz#fb0026885b9ac9f48bac1e185e4af472971149ff"
   integrity sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.12.3:
   version "6.12.6"
@@ -1046,6 +1121,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -1108,6 +1188,13 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+debug@4:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -1615,6 +1702,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -2405,6 +2500,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -3363,6 +3463,11 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Adding Sentry SDK so we can track crash fail rate overall our releases

### _⚠️ I couldn't test this well enough so it would be good to find a way to make sure this works before merging it ⚠️_ 

### Preview

![Screenshot 2022-02-04 at 10 26 30](https://user-images.githubusercontent.com/29886766/152504672-8c0c2a04-f9d9-4d06-92f4-986485c2fb4e.png)

![Screenshot 2022-02-04 at 10 27 20](https://user-images.githubusercontent.com/29886766/152504794-9359abc8-1ac7-4c6f-a22d-55bc7f07d46f.png)