### PR TITLE
chore: add session tracking

### DIFF
--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -54,6 +54,10 @@ const failArgs = deepFreeze({
     NodeClient: class NodeClient {
       captureMessage() {}
     },
+    getCurrentHub: jest.fn(() => ({
+      startSession: jest.fn(),
+      endSession: jest.fn(),
+    })),
   },
 });
 

--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -53,10 +53,10 @@ const failArgs = deepFreeze({
     },
     NodeClient: class NodeClient {
       captureMessage() {}
+      captureSession() {}
     },
     getCurrentHub: jest.fn(() => ({
       startSession: jest.fn(),
-      endSession: jest.fn(),
     })),
   },
 });

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -93,13 +93,12 @@ exports.default = async function fail({ context, github, inputs, Sentry }) {
 
   const client = new Sentry.NodeClient({
     dsn: process.env.SENTRY_DSN,
-    release: `${inputs.repo}@${inputs.version}`,
   });
   client.captureMessage(`Release failed: ${inputs.repo}`, "error", null, scope);
 
   const session = Sentry.getCurrentHub().startSession({
-    release,
-    status: "crashed"
+    release: `${inputs.repo}@${inputs.version}`,
+    status: "crashed",
   });
   client.captureSession(session);
 };

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -97,6 +97,9 @@ exports.default = async function fail({ context, github, inputs, Sentry }) {
   });
   client.captureMessage(`Release failed: ${inputs.repo}`, "error", null, scope);
 
-  const session = Sentry.getCurrentHub().startSession({ status: "crashed" });
-  Sentry.getCurrentHub().endSession(session);
+  const session = Sentry.getCurrentHub().startSession({
+    release,
+    status: "crashed"
+  });
+  client.captureSession(session);
 };

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -96,4 +96,7 @@ exports.default = async function fail({ context, github, inputs, Sentry }) {
     release: `${inputs.repo}@${inputs.version}`,
   });
   client.captureMessage(`Release failed: ${inputs.repo}`, "error", null, scope);
+
+  const session = Sentry.getCurrentHub().startSession({ status: "crashed" });
+  Sentry.getCurrentHub().endSession(session);
 };

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -91,13 +91,15 @@ exports.default = async function fail({ context, github, inputs, Sentry }) {
     inputs,
   });
 
+  const release = `${inputs.repo}@${inputs.version}`;
   const client = new Sentry.NodeClient({
+    release,
     dsn: process.env.SENTRY_DSN,
   });
   client.captureMessage(`Release failed: ${inputs.repo}`, "error", null, scope);
 
   const session = Sentry.getCurrentHub().startSession({
-    release: `${inputs.repo}@${inputs.version}`,
+    release,
     status: "crashed",
   });
   client.captureSession(session);

--- a/src/publish/success.js
+++ b/src/publish/success.js
@@ -30,7 +30,6 @@ exports.default = async function success({ context, github, inputs, Sentry }) {
 
   const client = new Sentry.NodeClient({
     dsn: process.env.SENTRY_DSN,
-    release: `${inputs.repo}@${inputs.version}`,
   });
   client.captureMessage(
     `Release succeeded: ${inputs.repo}`,
@@ -39,6 +38,9 @@ exports.default = async function success({ context, github, inputs, Sentry }) {
     scope
   );
 
-  const session = Sentry.getCurrentHub().startSession({ status: "ok" });
-  Sentry.getCurrentHub().endSession(session);
+  const session = Sentry.getCurrentHub().startSession({
+    release: `${inputs.repo}@${inputs.version}`,
+    status: "crashed",
+  });
+  client.captureSession(session);
 };

--- a/src/publish/success.js
+++ b/src/publish/success.js
@@ -28,8 +28,10 @@ exports.default = async function success({ context, github, inputs, Sentry }) {
     inputs,
   });
 
+  const release = `${inputs.repo}@${inputs.version}`;
   const client = new Sentry.NodeClient({
     dsn: process.env.SENTRY_DSN,
+    release,
   });
   client.captureMessage(
     `Release succeeded: ${inputs.repo}`,
@@ -39,8 +41,8 @@ exports.default = async function success({ context, github, inputs, Sentry }) {
   );
 
   const session = Sentry.getCurrentHub().startSession({
-    release: `${inputs.repo}@${inputs.version}`,
-    status: "crashed",
+    release,
+    status: "ok",
   });
   client.captureSession(session);
 };

--- a/src/publish/success.js
+++ b/src/publish/success.js
@@ -38,4 +38,7 @@ exports.default = async function success({ context, github, inputs, Sentry }) {
     null,
     scope
   );
+
+  const session = Sentry.getCurrentHub().startSession({ status: "ok" });
+  Sentry.getCurrentHub().endSession(session);
 };


### PR DESCRIPTION
Add session tracking to enable calculation of release health / crash-free rate in Sentry releases tab.