### PR TITLE
ref: Simplify Sentry SDK code

### DIFF
--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -48,16 +48,13 @@ const failArgs = deepFreeze({
   },
   Sentry: {
     Scope: class Scope {
-      setTag() {}
-      setContext() {}
+      update() {}
     },
     NodeClient: class NodeClient {
       captureMessage() {}
       captureSession() {}
     },
-    getCurrentHub: jest.fn(() => ({
-      startSession: jest.fn(),
-    })),
+    Session: class Session {},
   },
 });
 


### PR DESCRIPTION
With the latest, `6.17.5` version of SDK, we don't need to use `getCurrentHub` for creating `Session` object.