### PR TITLE
feat: Add GPG_SECRET_KEY and GPG_PASSPHRASE secrets for craft

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           NUGET_API_TOKEN: ${{ secrets.NUGET_API_TOKEN }}
+          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Inform about failure
         if: ${{ failure() }}


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/getsentry/craft/pull/346

To generate a valid secret key:

```terminal
gpg --quick-generate-key bot@sentry.io
gpg --armor --export-secret-keys bot@sentry.io | pbcopy
```

Paste copied key as `GPG_SECRET_KEY` and entered password as `GPG_PASSPHRASE`.