### PR TITLE
fix gpg secret env var name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           NUGET_API_TOKEN: ${{ secrets.NUGET_API_TOKEN }}
-          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Inform about failure


### PR DESCRIPTION
PR #804 added `GPG_SECRET_KEY` but craft uses `GPG_PRIVATE_KEY` instead