### PR TITLE
feat: Add PUBDEV_ACCESS_TOKEN and PUBDEV_REFRESH_TOKEN secrets for craft

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,8 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          PUBDEV_ACCESS_TOKEN: ${{ secrets.PUBDEV_ACCESS_TOKEN }}
+          PUBDEV_REFRESH_TOKEN: ${{ secrets.PUBDEV_REFRESH_TOKEN }}
 
       - name: Inform about failure
         if: ${{ failure() }}


### PR DESCRIPTION
For Dart and Flutter via `pub-dev` target.