### PR TITLE
feat: Allow for retracting a request release

### DIFF
--- a/.github/workflows/retract.yml
+++ b/.github/workflows/retract.yml
@@ -1,0 +1,37 @@
+name: Retract Release
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  retract:
+    runs-on: ubuntu-latest
+    name: Retract a release
+    if: ${{ !github.event.issue.pull_request && github.event.comment.body == '#retract' }}
+    steps:
+      - name: Get repo contents
+        uses: actions/checkout@v2
+        with:
+          path: .__publish__
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: yarn
+          cache-dependency-path: .__publish__/yarn.lock
+
+      - name: Parse and set inputs
+        id: inputs
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const inputs = require(`${process.env.GITHUB_WORKSPACE}/.__publish__/src/publish/inputs.js`).default;
+            return await inputs({context});
+
+      - name: Comment and close
+        uses: actions/github-script@v5
+        if: ${{ fromJSON(steps.inputs.outputs.result).requester == github.event.sender.login }}
+        with:
+          script: |
+            const inputs = require(`${process.env.GITHUB_WORKSPACE}/.__publish__/retract.js`).default;
+            return await inputs({context, github});

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ By default, all releases will be merged to the default branch of your repository
     ```
 1. In the same file, add `merge_target: ${{ github.event.inputs.merge_target }}` under the `with` block of the `Prepare release` step
 
+## Retracting Release Request
+
+To restract a release request, comment `#retract` (as the only comment content) under the request you want to retract.
+The only person that can do retract a release, is the same person that initially requested it and is listed in the request description.
+
 ## Under the hood
 
 The system uses [Craft](https://github.com/getsentry/craft) under the hood to prepare and publish releases. It uses `GH_SENTRY_BOT_PAT` personal access token, tied to the [getsentry-bot](https://github.com/getsentry-bot) account to perform repository actions automatically. This account is a member of the [release-bot team](https://github.com/orgs/getsentry/teams/release-bot). The reason for using a team is to ease role-based ACLs and making the rotation of the bot account itself if/when needed.

--- a/src/publish/__tests__/inputs.js
+++ b/src/publish/__tests__/inputs.js
@@ -57,6 +57,7 @@ test("parse inputs", async () => {
       "merge_target": "custom-branch",
       "path": ".",
       "repo": "sentry",
+      "requester": "BYK",
       "targets": Array [
         "github",
         "docker[latest]",
@@ -65,7 +66,6 @@ test("parse inputs", async () => {
     }
   `);
 });
-
 
 const defaultTargetInputsArgs = deepFreeze({
   context: {
@@ -101,6 +101,7 @@ test("Do not extract merge_target value if its a default value", async () => {
       "merge_target": "",
       "path": ".",
       "repo": "sentry",
+      "requester": "BYK",
       "targets": Array [
         "github",
         "docker[latest]",

--- a/src/publish/inputs.js
+++ b/src/publish/inputs.js
@@ -6,14 +6,21 @@ exports.default = async function inputs({ context }) {
     : "";
   const path = "." + (titleMatch.path || "");
 
+  // - May only contain alphanumeric characters and hyphens.
+  // - Cannot have multiple consecutive hyphens.
+  // - Cannot begin or end with a hyphen.
+  // - Maximum 39 characters.
+  const requesterParser = /^Requested by: @(?<requester>[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38})$/m;
+  const { requester } = context.payload.issue.body.match(
+    requesterParser
+  ).groups;
+
   // https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags
   const mergeTargetParser = /^Merge target: (?<merge_target>[\w.\-/]+)$/m;
-  const mergeTargetMatch = context.payload.issue.body.match(
-    mergeTargetParser
-  )
-  let merge_target = '';
+  const mergeTargetMatch = context.payload.issue.body.match(mergeTargetParser);
+  let merge_target = "";
   if (mergeTargetMatch && mergeTargetMatch.groups) {
-    merge_target = mergeTargetMatch.groups.merge_target || ''
+    merge_target = mergeTargetMatch.groups.merge_target || "";
   }
 
   const targetsParser = /^(?!### Targets$\s)(?: *- \[[ x]\] [\w.[\]-]+$(?:\r?\n)?)+/m;
@@ -26,5 +33,12 @@ exports.default = async function inputs({ context }) {
     );
   }
 
-  return { ...titleMatch, merge_target, path, dry_run, targets };
+  return {
+    ...titleMatch,
+    dry_run,
+    merge_target,
+    path,
+    requester,
+    targets,
+  };
 };

--- a/src/publish/retract.js
+++ b/src/publish/retract.js
@@ -1,0 +1,17 @@
+exports.default = async function success({ context, github }) {
+  const repoInfo = context.repo;
+
+  await Promise.all([
+    github.rest.issues.createComment({
+      ...repoInfo,
+      issue_number: context.payload.issue.number,
+      body: `Release request retracted by @${context.payload.sender.login}`,
+    }),
+
+    github.rest.issues.update({
+      ...repoInfo,
+      issue_number: context.payload.issue.number,
+      state: "closed",
+    }),
+  ]);
+};


### PR DESCRIPTION
This will only comment and close the original issue.

It will *not* cancel any running actions nor will it remove the release branch.
This is to keep it simple for now, not leave actions in the middle of some random state, and to not accidentally remove someone's release branch if it was created by hand.

Closes https://github.com/getsentry/publish/pull/882/