### PR TITLE
ref: Update targets on canceled runs too

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,18 @@ jobs:
           PUBDEV_ACCESS_TOKEN: ${{ secrets.PUBDEV_ACCESS_TOKEN }}
           PUBDEV_REFRESH_TOKEN: ${{ secrets.PUBDEV_REFRESH_TOKEN }}
 
+      - name: Update completed targets
+        if: ${{ cancelled() || failure() }}
+        uses: actions/github-script@v5
+        env:
+          PUBLISH_ARGS: ${{ steps.inputs.outputs.result }}
+        with:
+          script: |
+            const Sentry = require('@sentry/node');
+            const inputs = JSON.parse(process.env.PUBLISH_ARGS);
+            const updateTargets = require(`${process.env.GITHUB_WORKSPACE}/.__publish__/src/publish/update-targets.js`).default;
+            return await updateTargets({context, github, inputs});
+
       - name: Inform about failure
         if: ${{ failure() }}
         uses: actions/github-script@v5

--- a/src/publish/__tests__/fail.js
+++ b/src/publish/__tests__/fail.js
@@ -88,15 +88,9 @@ Assign the **accepted** label to this issue to approve the release.\r
   });
 });
 
-describe.each([false, true])("state file exists: %s", (stateFileExists) => {
+describe("publish failed", () => {
   beforeEach(async () => {
-    fs.existsSync = jest.fn(() => stateFileExists);
     await fail(failArgs);
-    expect(fs.existsSync).toHaveBeenCalledTimes(1);
-    // This is process.env.GITHUB_WORKSPACE + / filename
-    expect(fs.existsSync).toHaveBeenCalledWith(
-      "./__repo__/.craft-publish-21.3.1.json"
-    );
   });
 
   test("create comment", async () => {
@@ -121,55 +115,4 @@ describe.each([false, true])("state file exists: %s", (stateFileExists) => {
       name: "accepted",
     });
   });
-
-  if (stateFileExists) {
-    test("restore publish state", async () => {
-      expect(failArgs.github.rest.issues.get).toHaveBeenCalledTimes(1);
-      expect(failArgs.github.rest.issues.get.mock.calls[0])
-        .toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "issue_number": "211",
-            "owner": "getsentry",
-            "repo": "publish",
-          },
-        ]
-      `);
-
-      expect(failArgs.github.rest.issues.update).toHaveBeenCalledTimes(1);
-      expect(failArgs.github.rest.issues.update.mock.calls[0])
-        .toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "body": "
-        Requested by: @BYK
-        
-        Merge target: (default)
-
-        Quick links:
-        - [View changes](https://github.com/getsentry/sentry/compare/21.3.0...refs/heads/releases/21.3.1)
-        - [View check runs](https://github.com/getsentry/sentry/commit/7e5ca7ed5581552de066e2a8bc295b8306be38ac/checks/)
-
-        Assign the **accepted** label to this issue to approve the release.
-        
-        ### Targets
-        - [x] github
-        - [ ] pypi
-        - [ ] docker[release]
-        - [ ] docker[latest]
-        - [x] lol
-        - [ ] hey
-        ",
-            "issue_number": "211",
-            "owner": "getsentry",
-            "repo": "publish",
-          },
-        ]
-      `);
-    });
-  } else {
-    test("don't modify issue body", () => {
-      expect(failArgs.github.rest.issues.update).not.toHaveBeenCalled();
-    });
-  }
 });

--- a/src/publish/__tests__/update-targets.js
+++ b/src/publish/__tests__/update-targets.js
@@ -1,0 +1,156 @@
+/* eslint-env jest */
+
+jest.mock("fs");
+
+const fs = require("fs");
+const updateTargets = require("../update-targets.js").default;
+
+function deepFreeze(object) {
+  // Retrieve the property names defined on object
+  const propNames = Object.getOwnPropertyNames(object);
+
+  // Freeze properties before freezing self
+
+  for (const name of propNames) {
+    const value = object[name];
+
+    if (value && typeof value === "object") {
+      deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(object);
+}
+
+const updateTargetsArgs = deepFreeze({
+  inputs: { repo: "sentry", version: "21.3.1" },
+  context: {
+    runId: "1234",
+    repo: { owner: "getsentry", repo: "publish" },
+    payload: { issue: { number: "211" } },
+  },
+  github: {
+    rest: {
+      actions: {
+        getWorkflowRun: async () => ({
+          data: {
+            html_url: "https://github.com/getsentry/sentry/actions/runs/1234",
+          },
+        }),
+      },
+      issues: {
+        get: jest.fn(),
+        update: jest.fn(),
+        createComment: jest.fn(),
+        removeLabel: jest.fn(),
+      },
+    },
+  },
+  Sentry: {
+    Scope: class Scope {
+      update() {}
+    },
+    NodeClient: class NodeClient {
+      captureMessage() {}
+      captureSession() {}
+    },
+    Session: class Session {},
+  },
+});
+
+beforeAll(() => {
+  process.env.GITHUB_WORKSPACE = ".";
+  fs.promises = {};
+  fs.promises.readFile = jest.fn(async () =>
+    JSON.stringify({ published: { lol: true, hey: false, github: true } })
+  );
+
+  updateTargetsArgs.github.rest.issues.get.mockReturnValue({
+    data: {
+      body: `
+Requested by: @BYK
+
+Merge target: (default)
+
+Quick links:
+- [View changes](https://github.com/getsentry/sentry/compare/21.3.0...refs/heads/releases/21.3.1)
+- [View check runs](https://github.com/getsentry/sentry/commit/7e5ca7ed5581552de066e2a8bc295b8306be38ac/checks/)
+
+Assign the **accepted** label to this issue to approve the release.\r
+
+### Targets\r
+- [ ] github
+- [ ] pypi\r
+- [ ] docker[release]\r
+- [ ] docker[latest]  
+`,
+    },
+  });
+});
+
+describe.each([false, true])("state file exists: %s", (stateFileExists) => {
+  beforeEach(async () => {
+    fs.existsSync = jest.fn(() => stateFileExists);
+    await updateTargets(updateTargetsArgs);
+    expect(fs.existsSync).toHaveBeenCalledTimes(1);
+    // This is process.env.GITHUB_WORKSPACE + / filename
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      "./__repo__/.craft-publish-21.3.1.json"
+    );
+  });
+
+  if (stateFileExists) {
+    test("restore publish state", async () => {
+      expect(updateTargetsArgs.github.rest.issues.get).toHaveBeenCalledTimes(1);
+      expect(updateTargetsArgs.github.rest.issues.get.mock.calls[0])
+        .toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "issue_number": "211",
+            "owner": "getsentry",
+            "repo": "publish",
+          },
+        ]
+      `);
+
+      expect(updateTargetsArgs.github.rest.issues.update).toHaveBeenCalledTimes(
+        1
+      );
+      expect(updateTargetsArgs.github.rest.issues.update.mock.calls[0])
+        .toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "body": "
+        Requested by: @BYK
+        
+        Merge target: (default)
+
+        Quick links:
+        - [View changes](https://github.com/getsentry/sentry/compare/21.3.0...refs/heads/releases/21.3.1)
+        - [View check runs](https://github.com/getsentry/sentry/commit/7e5ca7ed5581552de066e2a8bc295b8306be38ac/checks/)
+
+        Assign the **accepted** label to this issue to approve the release.
+        
+        ### Targets
+        - [x] github
+        - [ ] pypi
+        - [ ] docker[release]
+        - [ ] docker[latest]
+        - [x] lol
+        - [ ] hey
+        ",
+            "issue_number": "211",
+            "owner": "getsentry",
+            "repo": "publish",
+          },
+        ]
+      `);
+    });
+  } else {
+    test("don't modify issue body", () => {
+      expect(
+        updateTargetsArgs.github.rest.issues.update
+      ).not.toHaveBeenCalled();
+    });
+  }
+});

--- a/src/publish/fail.js
+++ b/src/publish/fail.js
@@ -1,5 +1,3 @@
-const fs = require("fs");
-
 exports.default = async function fail({ context, github, inputs, Sentry }) {
   const { repo, version } = inputs;
 
@@ -12,62 +10,7 @@ exports.default = async function fail({ context, github, inputs, Sentry }) {
   ).data;
   const issue_number = context.payload.issue.number;
 
-  const CRAFT_STATE_FILE_PATH = `${process.env.GITHUB_WORKSPACE}/__repo__/.craft-publish-${version}.json`;
-  let updateIssueBodyRequest;
-  if (fs.existsSync(CRAFT_STATE_FILE_PATH)) {
-    const issueRequest = github.rest.issues.get({
-      ...repoInfo,
-      issue_number,
-    });
-
-    const craftStateRequest = fs.promises
-      .readFile(CRAFT_STATE_FILE_PATH, { encoding: "utf-8" })
-      .then((data) => JSON.parse(data));
-
-    const [{ data: issue }, craftState] = await Promise.all([
-      issueRequest,
-      craftStateRequest,
-    ]);
-
-    const targetsParser = /^(?!### Targets$\s)^(?: *- \[[ x]\] [\w.[\]-]+[ ]*$(?:\r?\n)?)+/m;
-    const declaredTargets = new Set();
-    let leadingSpaces = " ";
-    const newIssueBody = issue.body.replace(targetsParser, (targetsSection) => {
-      let targetsText = targetsSection.trimRight();
-      const targetMatcher = /^( *)- \[[ x]\] ([\w.[\]-]+)$/gim;
-      targetsText = targetsText.replace(
-        targetMatcher,
-        (_match, spaces, target) => {
-          leadingSpaces = spaces;
-          declaredTargets.add(target);
-          const x = craftState.published[target] ? "x" : " ";
-          return `${spaces}- [${x}] ${target}`;
-        }
-      );
-      const unlistedTargets = Object.keys(craftState.published)
-        .filter((target) => !declaredTargets.has(target))
-        .map(
-          (target) =>
-            `${leadingSpaces}- [${
-              craftState.published[target] ? "x" : " "
-            }] ${target}`
-        )
-        .join("\n");
-      targetsText += `\n${unlistedTargets}\n`;
-      return targetsText;
-    });
-
-    updateIssueBodyRequest = github.rest.issues.update({
-      ...repoInfo,
-      issue_number,
-      body: newIssueBody,
-    });
-  } else {
-    updateIssueBodyRequest = Promise.resolve();
-  }
-
   await Promise.all([
-    updateIssueBodyRequest,
     github.rest.issues.createComment({
       ...repoInfo,
       issue_number,

--- a/src/publish/update-targets.js
+++ b/src/publish/update-targets.js
@@ -1,0 +1,65 @@
+const fs = require("fs");
+
+exports.default = async function updateTargets({ context, github, inputs }) {
+  const { version } = inputs;
+
+  const repoInfo = context.repo;
+  const issue_number = context.payload.issue.number;
+
+  const CRAFT_STATE_FILE_PATH = `${process.env.GITHUB_WORKSPACE}/__repo__/.craft-publish-${version}.json`;
+  let updateIssueBodyRequest;
+
+  if (fs.existsSync(CRAFT_STATE_FILE_PATH)) {
+    const issueRequest = github.rest.issues.get({
+      ...repoInfo,
+      issue_number,
+    });
+
+    const craftStateRequest = fs.promises
+      .readFile(CRAFT_STATE_FILE_PATH, { encoding: "utf-8" })
+      .then((data) => JSON.parse(data));
+
+    const [{ data: issue }, craftState] = await Promise.all([
+      issueRequest,
+      craftStateRequest,
+    ]);
+
+    const targetsParser = /^(?!### Targets$\s)^(?: *- \[[ x]\] [\w.[\]-]+[ ]*$(?:\r?\n)?)+/m;
+    const declaredTargets = new Set();
+    let leadingSpaces = " ";
+    const newIssueBody = issue.body.replace(targetsParser, (targetsSection) => {
+      let targetsText = targetsSection.trimRight();
+      const targetMatcher = /^( *)- \[[ x]\] ([\w.[\]-]+)$/gim;
+      targetsText = targetsText.replace(
+        targetMatcher,
+        (_match, spaces, target) => {
+          leadingSpaces = spaces;
+          declaredTargets.add(target);
+          const x = craftState.published[target] ? "x" : " ";
+          return `${spaces}- [${x}] ${target}`;
+        }
+      );
+      const unlistedTargets = Object.keys(craftState.published)
+        .filter((target) => !declaredTargets.has(target))
+        .map(
+          (target) =>
+            `${leadingSpaces}- [${
+              craftState.published[target] ? "x" : " "
+            }] ${target}`
+        )
+        .join("\n");
+      targetsText += `\n${unlistedTargets}\n`;
+      return targetsText;
+    });
+
+    updateIssueBodyRequest = github.rest.issues.update({
+      ...repoInfo,
+      issue_number,
+      body: newIssueBody,
+    });
+  } else {
+    updateIssueBodyRequest = Promise.resolve();
+  }
+
+  await updateIssueBodyRequest;
+};


### PR DESCRIPTION
GH Actions timeouts are not treated as `failed` but rather `canceled`. Because of that, release attempts that failed after some targets already succeeded were not updated with appropriate checkboxes.

This PR extracts targets update logic to a separate action, and triggers it in case of failure *and* canceled runs.