### PR TITLE
ref: Set timeout-minutes to 60 instead of default 360

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish a new version
     if: github.event.label.name == 'accepted' && github.event.issue.state == 'open'
+    timeout-minutes: 60
     env:
       SENTRY_DSN: "https://303a687befb64dc2b40ce4c96de507c5@o1.ingest.sentry.io/6183838"
     steps:


### PR DESCRIPTION
Default 6 hours is a huge overkill. The only target that can take time even remotely close to this is `sentry-java` with its `maven` target which retries for 30 minutes.

This allows us for faster retriggers in case something goes wrong with (usually) gh artifacts upload, without the assistance of someone with admin permissions to cancel runs.