### PR TITLE
deps: Lock @sentry/node to v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           cache-dependency-path: .__publish__/yarn.lock
 
       - name: Install Sentry SDK
-        run: yarn add @sentry/node
+        run: yarn add @sentry/node@6
 
       - name: Parse and set inputs
         id: inputs


### PR DESCRIPTION
We can either:
- lock the major
- update the code
- remove this feature completely (counting failed/successful deploys) (I'd go with this one tbh)

For now locking is quickest, so we can unlock the deploys.

ref: https://github.com/getsentry/publish/runs/6813933024?check_suite_focus=true#step:13:24