### PR TITLE
fix(retract): Use node script for input.js

### DIFF
--- a/.github/workflows/retract.yml
+++ b/.github/workflows/retract.yml
@@ -29,11 +29,7 @@ jobs:
 
       - name: Parse and set inputs
         id: inputs
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const inputs = require(`${process.env.GITHUB_WORKSPACE}/.__publish__/src/publish/inputs.js`).default;
-            return await inputs({context});
+        run: node .__publish__/src/publish/inputs.js
 
       - name: Comment and close
         uses: actions/github-script@v5


### PR DESCRIPTION
In https://github.com/getsentry/publish/pull/1342 we merged in changes that converted `Parse and set inputs` step to use a node script instead of a inline script. This needs to be also done for the retract action, which is what this PR does. 

This is blocking retracting https://github.com/getsentry/publish/issues/1358, which is needed to unblock a backport bug fix!