### PR TITLE
Throw a useful error when GITHUB_TOKEN is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 node_modules
 package-lock.json
+coverage/

--- a/src/libs/__tests__/github.js
+++ b/src/libs/__tests__/github.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+
+jest.mock("fs");
+
+const {getGitHubToken} = require("../github.js");
+
+describe("getGitHubToken", () => {
+  test("throw if no token is defined", async () => {
+    delete process.env.GITHUB_TOKEN
+    expect(() => getGitHubToken()).toThrow('No "GITHUB_TOKEN" environment variable found.')
+  });
+
+  test("return token if defined", async () => {
+    process.env.GITHUB_TOKEN = "Example Token"
+    expect(getGitHubToken()).toEqual("Example Token")
+  });
+});

--- a/src/libs/github.js
+++ b/src/libs/github.js
@@ -1,0 +1,17 @@
+/**
+ * This is a helper function that throws a useful error message if the
+ * workflow environment is not configured correctly.
+ *
+ * @returns string
+ */
+function getGitHubToken() {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error('No "GITHUB_TOKEN" environment variable found. ' +
+    'Please ensure the workflow is configured correctly');
+  }
+  return process.env.GITHUB_TOKEN;
+}
+
+module.exports = {
+  getGitHubToken,
+};

--- a/src/publish/post-result.js
+++ b/src/publish/post-result.js
@@ -1,8 +1,9 @@
 const processEndState = require('../modules/process-end-state');
+const {getGitHubToken} = require('../libs/github');
 const github = require('@actions/github');
 
 const context = github.context;
-const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+const octokit = github.getOctokit(getGitHubToken());
 const inputs = JSON.parse(process.env.PUBLISH_ARGS);
 const args = process.argv.slice(2);
 const status = args[0];

--- a/src/publish/post-workflow-details.js
+++ b/src/publish/post-workflow-details.js
@@ -1,7 +1,8 @@
 const postWorkflowDetails = require('../modules/post-workflow-details.js');
+const {getGitHubToken} = require('../libs/github');
 const github = require('@actions/github');
 
 const context = github.context;
-const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+const octokit = github.getOctokit(getGitHubToken());
 
 postWorkflowDetails({context, octokit});

--- a/src/publish/retract.js
+++ b/src/publish/retract.js
@@ -1,8 +1,9 @@
 const github = require('@actions/github');
 const retract = require('../modules/retract-release');
+const {getGitHubToken} = require('../libs/github');
 
 const context = github.context;
-const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+const octokit = github.getOctokit(getGitHubToken());
 const inputs = JSON.parse(process.env.PUBLISH_ARGS);
 
 retract({context, octokit, inputs});

--- a/src/publish/update-issue.js
+++ b/src/publish/update-issue.js
@@ -1,8 +1,9 @@
 const updateIssue = require('../modules/update-issue.js');
+const {getGitHubToken} = require('../libs/github');
 const github = require('@actions/github');
 
 const context = github.context;
-const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+const octokit = github.getOctokit(getGitHubToken());
 const inputs = JSON.parse(process.env.PUBLISH_ARGS);
 
 updateIssue({ context, octokit, inputs });


### PR DESCRIPTION
Changes output from:

<img width="1010" alt="Screen Shot 2022-09-27 at 2 27 38 PM" src="https://user-images.githubusercontent.com/112419115/192643515-529dc2ce-b8c6-402a-9720-7614a614dc99.png">

To the following:

<img width="1010" alt="Screen Shot 2022-09-27 at 2 27 17 PM" src="https://user-images.githubusercontent.com/112419115/192643565-e5f7e2df-18e1-49d2-a184-11b3c489a8b0.png">

Should this ever happen again in the future, the warning should highlight the issue quickly.