### PR TITLE
fix: Checking out wrong branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,7 @@ jobs:
           repository: getsentry/${{ fromJSON(steps.inputs.outputs.result).repo }}
           token: ${{ secrets.GH_SENTRY_BOT_PAT }}
           fetch-depth: 0
+          ref: ${{ fromJSON(steps.inputs.outputs.result).version }}
 
       - name: Set targets
         shell: bash


### PR DESCRIPTION
The workflow always get the main branch before using craft.
Thats cause the wrong .craft.yml file to be used in case we update it.