### PR TITLE
chore: Change timeout to 90 minutes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish a new version
     if: github.event.label.name == 'accepted' && github.event.issue.state == 'open'
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       SENTRY_DSN: "https://303a687befb64dc2b40ce4c96de507c5@o1.ingest.sentry.io/6183838"
     steps:


### PR DESCRIPTION
We had a few publish [runs](https://github.com/getsentry/publish/actions) for the sentry android gradle plugin cancelled because maven central (hosting for java packages) is recently very slow https://status.maven.org/. Also opened a PR to craft to increase the deadline for releasing to Maven to 60min. https://github.com/getsentry/craft/pull/450