### PR TITLE
Workaround git safe.directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,10 @@ jobs:
           '[{($source[]): true }] | add | {"published": (. // {}) }'
           > __repo__/.craft-publish-${{ fromJSON(steps.inputs.outputs.result).version }}.json
 
+      # See https://github.com/actions/runner/issues/2033
+      - name: Fix git safe.directory in container
+        run: mkdir -p /home/runner/work/_temp/_github_home && printf "[safe]\n\tdirectory = /github/workspace" > /home/runner/work/_temp/_github_home/.gitconfig
+
       - uses: docker://getsentry/craft:latest
         name: Publish using Craft
         with:


### PR DESCRIPTION
Apply workaround mentioned in https://github.com/actions/runner/issues/2033

To hopefully workaround:

```
Error:  fatal: detected dubious ownership in repository at '/github/workspace/__repo__'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace/__repo__

  To add an exception for this directory, call:
  
  git config --global --add safe.directory /github/workspace/__repo__
```

https://github.com/getsentry/publish/actions/runs/4088671361/jobs/7050581556#step:10:47

Note: https://github.com/getsentry/craft/pull/455 did not work.

@asottile-sentry 