### PR TITLE
fix: Add json-schema-diff to auto-approve list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,6 +10,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/arroyo@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/pytest-sentry@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/json-schema-diff@') ||
         false
       )
     steps:


### PR DESCRIPTION
This is an aux dependency of sentry-kafka-schemas
