### PR TITLE
feat: Auto-approve releases of relay library

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -12,6 +12,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/json-schema-diff@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-redis-tools@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/relay/py@') ||
         false
       )
     steps:


### PR DESCRIPTION
From the README:

> Internal dependencies such as arroyo can be published with an auto approval. The reasoning here is that the bump of the dependency requires an explicit approval again in Sentry proper.

This is true for the relay python library IMO.

https://github.com/getsentry/publish#approvals