### PR TITLE
Add responses to the auto approve list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -13,6 +13,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/json-schema-diff@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-redis-tools@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/relay/py@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/responses@') ||
         false
       )
     steps:


### PR DESCRIPTION
This isn't an SDK and doesn't need the compliance checkpoint that SDKs do.