### PR TITLE
ref: Auto-approve statsdproxy

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -17,6 +17,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-djangorestframework-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-redis-tools@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/statsdproxy@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/snuba-sdk@') ||
         false
       )


### PR DESCRIPTION
It's an internal Rust package we use for reporting metrics
