### PR TITLE
feat(publish): Use craft config from merge target if configured

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           path: __repo__
           repository: getsentry/${{ fromJSON(steps.inputs.outputs.result).repo }}
+          # If we extracted `merge_target` from the parsed issue, check out the merge target branch, otherwise fall back to the default branch
+          ref: ${{ fromJSON(steps.inputs.outputs.result).craft_config_branch == 'merge_target' && fromJSON(steps.inputs.outputs.result).merge_target || '' }}
           token: ${{ secrets.GH_SENTRY_BOT_PAT }}
           fetch-depth: 0
 

--- a/src/modules/details-from-context.js
+++ b/src/modules/details-from-context.js
@@ -1,9 +1,10 @@
 async function detailsFromContext({ context }) {
   if (!context || !context.payload || !context.payload.issue) {
-    throw new Error('Issue context is not defined');
+    throw new Error("Issue context is not defined");
   }
 
-  const titleParser = /^publish: (?:getsentry\/)?(?<repo>[^/@]+)(?<path>\/[\w./-]+)?@(?<version>[\w.+-]+)$/;
+  const titleParser =
+    /^publish: (?:getsentry\/)?(?<repo>[^/@]+)(?<path>\/[\w./-]+)?@(?<version>[\w.+-]+)$/;
   const titleMatch = context.payload.issue.title.match(titleParser).groups;
   const dry_run = context.payload.issue.labels.some((l) => l.name === "dry-run")
     ? "1"
@@ -14,10 +15,10 @@ async function detailsFromContext({ context }) {
   // - Cannot have multiple consecutive hyphens.
   // - Cannot begin or end with a hyphen.
   // - Maximum 39 characters.
-  const requesterParser = /^Requested by: @(?<requester>[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38})$/m;
-  const { requester } = context.payload.issue.body.match(
-    requesterParser
-  ).groups;
+  const requesterParser =
+    /^Requested by: @(?<requester>[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38})$/m;
+  const { requester } =
+    context.payload.issue.body.match(requesterParser).groups;
 
   // https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags
   const mergeTargetParser = /^Merge target: (?<merge_target>[\w.\-/]+)$/m;
@@ -27,7 +28,17 @@ async function detailsFromContext({ context }) {
     merge_target = mergeTargetMatch.groups.merge_target || "";
   }
 
-  const targetsParser = /^(?!### Targets$\s)(?: *- \[[ x]\] [\w.[\]-]+$(?:\r?\n)?)+/m;
+  const craftConfigParser =
+    /^Using Craft config from: (?<config_branch>[\w._/]+)$/m;
+  const craftConfigMatch = context.payload.issue.body.match(craftConfigParser);
+  let craft_config_branch =
+    (craftConfigMatch &&
+      craftConfigMatch.groups &&
+      craftConfigMatch.groups.config_branch) ||
+    "default";
+
+  const targetsParser =
+    /^(?!### Targets$\s)(?: *- \[[ x]\] [\w.[\]-]+$(?:\r?\n)?)+/m;
   const targetsMatch = context.payload.issue.body.match(targetsParser);
   let targets;
   if (targetsMatch) {
@@ -41,10 +52,11 @@ async function detailsFromContext({ context }) {
     ...titleMatch,
     dry_run,
     merge_target,
+    craft_config_branch,
     path,
     requester,
     targets,
   };
-};
+}
 
 module.exports = detailsFromContext;


### PR DESCRIPTION
This PR does 2 things:

1. Extract the merge target branch information added to the publish issue in https://github.com/getsentry/action-prepare-release/pull/35
2. Checkout the target repo on the merge target branch if we extracted `merge_target` from

In a follow up PR, I'll add an allowlist for repos and branches where we can take the config from and fall back if the merge target isn't included in the allowlist.

ref https://github.com/getsentry/publish/issues/3441