### PR TITLE
fix(publish): Fix incorrect merge target syntax

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,8 @@ jobs:
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-migr8' && fromJSON(steps.inputs.outputs.result).merge_target == 'tmp-merge-target'
         id: target-repo-branch
         run: |
-          target_repo_branch="{{ fromJSON(steps.inputs.outputs.result).merge_target }}"
-          echo 'taking craft config from branch {{ fromJSON(steps.inputs.outputs.result).merge_target }} in {{ fromJSON(steps.inputs.outputs.result).repo }}'
+          target_repo_branch="${{ fromJSON(steps.inputs.outputs.result).merge_target }}"
+          echo 'taking craft config from branch ${{ fromJSON(steps.inputs.outputs.result).merge_target }} in ${{ fromJSON(steps.inputs.outputs.result).repo }}'
 
       - uses: actions/checkout@v3
         name: Check out target repo


### PR DESCRIPTION
Well... 

Fix incorrect variable access syntax for the new target repo branch step introduced in #3451 