### PR TITLE
ref(publish): Add `sentry-javascript/master` branch to `target-repo-branch` step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
         # Note: Branches registered here MUST BE protected in the target repo!
         if: |
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-migr8' && fromJSON(steps.inputs.outputs.result).merge_target == 'tmp-merge-target' ||
-          fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v7' ||
+          fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && (fromJSON(steps.inputs.outputs.result).merge_target == 'v7' || fromJSON(steps.inputs.outputs.result).merge_target == 'master') ||
           false
         id: target-repo-branch
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,8 @@ jobs:
         # Note: Branches registered here MUST BE protected in the target repo!
         if: |
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-migr8' && fromJSON(steps.inputs.outputs.result).merge_target == 'tmp-merge-target' ||
-          fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && (fromJSON(steps.inputs.outputs.result).merge_target == 'v7' || fromJSON(steps.inputs.outputs.result).merge_target == 'master') ||
+          fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v7' ||
+          fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'master' ||
           false
         id: target-repo-branch
         run: |


### PR DESCRIPTION
This PR adds the `master` branch to the allowed branches we can take the craft config file from in `sentry-javascript`.
IMHO we should allow taking the config from `master` as well as from `v7` (as done in #3467):

* Our repo's default branch is `develop` while we release from `master` (more information on our [gitflow approach](https://github.com/getsentry/sentry-javascript/blob/develop/docs/gitflow.md)). So there is a chance that the craft config on `develop` is not aligned with the config on `master`, for instance in the case where the config is changed while a release is still in progress.
* I'd like to avoid using two different strategies of obtaining the craft config (i.e. once via the new opt in mechanism, once in the default way), which 1. increases consistency and 2. makes it easier for everyone on the team and surrounding teams to create releases, regardless of v7 or current version (v8)
* Branch protection rules for `master` and `develop` are aligned, so this requirement should be fulfilled. 
