### PR TITLE
feat: Add `status-page-list` to auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,10 +23,10 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-djangorestframework-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-redis-tools@') ||
-        startsWith(github.event.issue.title, 'publish: getsentry/status-page-list@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/skrooge@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/snuba-sdk@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/statsdproxy@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/status-page-list@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/symbolic@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/usage-accountant@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/watto@') ||

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,6 +23,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-djangorestframework-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-redis-tools@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/status-page-list@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/skrooge@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/snuba-sdk@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/statsdproxy@') ||


### PR DESCRIPTION
https://github.com/getsentry/status-page-list is a library we extracted out from the sentry frontend. It can be auto approved.