### PR TITLE
chore: add jest-sentry-environment to auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,6 +9,7 @@ jobs:
       github.actor == 'getsentry-release' && (
         startsWith(github.event.issue.title, 'publish: getsentry/arroyo@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/devenv@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/jest-sentry-environment@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/js-source-scopes@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/json-schema-diff@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/ophio@') ||


### PR DESCRIPTION
this package helps us monitor flakes in jest runs and has been dead for a bit