### PR TITLE
ref(publish): Add `sentry-wizard/1.x` branch to `target-repo-branch` step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-migr8' && fromJSON(steps.inputs.outputs.result).merge_target == 'tmp-merge-target' ||
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v7' ||
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'master' ||
+          fromJSON(steps.inputs.outputs.result).repo == 'sentry-wizard' && fromJSON(steps.inputs.outputs.result).merge_target == '1.x' ||
           false
         id: target-repo-branch
         run: |


### PR DESCRIPTION
Adds the `1.x` branch of the `sentry-wizard` repo to be one of the branches where we can take the craft config from. The config diverged between 1.x and 3.x (latest) and we need to cut a 1.x release. So I'd like to opt this branch into the mechanism we set up for the JS SDK repo. 