### PR TITLE
add `infra-event-notifier` to auto-approve list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,6 +9,7 @@ jobs:
       github.actor == 'getsentry-release' && (
         startsWith(github.event.issue.title, 'publish: getsentry/arroyo@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/devenv@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/infra-event-notifier@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/jest-sentry-environment@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/js-source-scopes@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/json-schema-diff@') ||


### PR DESCRIPTION
This adds https://github.com/getsentry/infra-event-notifier to the publish auto-approve list