### PR TITLE
chore: Add sentry-protos to the auto-approve list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -24,6 +24,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-django-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-djangorestframework-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/sentry-protos@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-redis-tools@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/skrooge@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/snuba-sdk@') ||


### PR DESCRIPTION
This repository will eventually contains shared protobuf schemas and generated bindings for rust/python/go. The packages produced from this repository will be used in production applications to facilitate cross-application messaging.