### PR TITLE
chore(approve): Add sentry-infra-tools to auto approve list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,6 +23,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/rust-usage-accountant@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-django-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-djangorestframework-stubs@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/sentry-infra-tools@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-protos@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-redis-tools@') ||


### PR DESCRIPTION
sentry-infra-tools repository is going to have tools used by sentry SRE to manage the infrastructure. It does not require elevated privileges to be released.