### PR TITLE
chore: Add sentry-forked-jsonnet to auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,6 +23,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/rust-usage-accountant@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-django-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-djangorestframework-stubs@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-jsonnet@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-infra-tools@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-kafka-schemas@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-protos@') ||


### PR DESCRIPTION
This PR adds sentry-forked-jsonnet to the auto-approve list