### PR TITLE
feat: Publish on macos with label

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     types: [labeled]
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.label.name == 'macos' && 'macos-latest' || 'ubuntu-latest' }}
     name: Publish a new version
     if: github.event.label.name == 'accepted' && github.event.issue.state == 'open'
     timeout-minutes: 90


### PR DESCRIPTION
Allow running the publish workflow on macOS when passing in the macos label.