### PR TITLE
fix(publish): Fix permission scope for auth token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+          owner: getsentry # create token that have access to all repos
 
       - uses: actions/checkout@v3
         name: Check out target repo


### PR DESCRIPTION
> If owner is set and repositories is empty, access will be scoped to all repositories in the provided repository owner's installation. If owner and repositories are empty, access will be scoped to only the current repository.

(https://github.com/actions/create-github-app-token?tab=readme-ov-file#repositories)

We need the GitHub app to have access not only to the `publish` repo, but also the target repo where we are publishing to