### PR TITLE
add  repo to auto-approve list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -37,6 +37,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/snuba-sdk@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/statsdproxy@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/status-page-list@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/streams@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/symbolic@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/usage-accountant@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/watto@') ||


### PR DESCRIPTION
This adds https://github.com/getsentry/streams to the auto-approve list