### PR TITLE
fix: actually auto-approve sentry_streams releases

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -37,7 +37,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/snuba-sdk@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/statsdproxy@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/status-page-list@') ||
-        startsWith(github.event.issue.title, 'publish: getsentry/streams@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/streams/sentry_streams@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/symbolic@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/usage-accountant@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/watto@') ||


### PR DESCRIPTION
Since `sentry_streams` is a package within the `streams` repo my original path was wrong - this should fix