### PR TITLE
fix: Clarify how to retract a release

### DIFF
--- a/src/modules/__tests__/update-issue.js
+++ b/src/modules/__tests__/update-issue.js
@@ -168,7 +168,7 @@ Quick links:
 - [View changes](https://github.com/getsentry/sentry-elixir/compare/2f5876adf89822cc75199576966df4fd587f68e9...refs/heads/release/10.7.2)
 - [View check runs](https://github.com/getsentry/sentry-elixir/commit/fcbc69b88481a95532d10a6162a243107fabb96a/checks/)
 Assign the **accepted** label to this issue to approve the release.
-Leave a comment containing \`#retract\` under this issue to retract the release (original issuer only).
+To retract the release, the person requesting it must leave a comment only containing \`#retract\` with no other text and quotes under this issue.
 
 ### Targets
 
@@ -188,7 +188,7 @@ Quick links:
 - [View changes](https://github.com/getsentry/sentry-elixir/compare/2f5876adf89822cc75199576966df4fd587f68e9...refs/heads/release/10.7.2)
 - [View check runs](https://github.com/getsentry/sentry-elixir/commit/fcbc69b88481a95532d10a6162a243107fabb96a/checks/)
 Assign the **accepted** label to this issue to approve the release.
-Leave a comment containing \`#retract\` under this issue to retract the release (original issuer only).
+To retract the release, the person requesting it must leave a comment only containing \`#retract\` with no other text and quotes under this issue..
 
 ### Targets
 


### PR DESCRIPTION
Clarify that you must leave a comment only containing retract and nothing else to retract a release.