### PR TITLE
Fix retract newline check

### DIFF
--- a/.github/workflows/retract.yml
+++ b/.github/workflows/retract.yml
@@ -12,7 +12,7 @@ jobs:
       !github.event.issue.pull_request &&
       contains(
         format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body),
-        fromJSON('"\r\n#retract\r\n"')
+        fromJSON('"\n#retract\n"')
       )
     steps:
       - name: Get repo contents

--- a/.github/workflows/retract.yml
+++ b/.github/workflows/retract.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       !github.event.issue.pull_request &&
       contains(
-        format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body),
+        format(fromJSON('"\n{0}\n"'), github.event.comment.body),
         fromJSON('"\n#retract\n"')
       )
     steps:


### PR DESCRIPTION
It seems like GH changed new lines from \r\n to \n and therefore the retract comment only worked if was added to a comment and the comment didn't contain any other text. This is fixed now by only checking for \n.

As pointed out here https://github.com/getsentry/action-prepare-release/pull/40#issuecomment-2872769352.