### PR TITLE
Add taskbroker to the auto-publish list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -41,6 +41,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/status-page-list@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/streams/sentry_streams@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/symbolic@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/taskbroker@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/usage-accountant@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/watto@') ||
         false


### PR DESCRIPTION
This application will be part of self-hosted releases in the future.