### PR TITLE
feat: auto-approve dry runs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,6 +10,7 @@ jobs:
         github.actor == 'getsentry-release' ||
         github.actor == 'sentry-release-bot[bot]'
       ) && (
+        contains(github.event.issue.labels.*.name, 'dry-run') ||
         startsWith(github.event.issue.title, 'publish: getsentry/arroyo@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/auto-type-annotate@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/devenv@') ||


### PR DESCRIPTION
This would be necessary to unlock the ability to test release workflows in nightly jobs or on PR check runs. Requiring an approval for these would not scale. Uses the syntax described [here](https://docs.github.com/en/actions/reference/evaluate-expressions-in-workflows-and-actions#example-using-an-object-filter) to search for the appropriate label.

AFAICT the `craft publish` invocation will automatically pick up the dry run option from:
1. https://github.com/getsentry/publish/blob/282135268008c6fc86b7672c71b5fcba233c1dc9/src/modules/details-from-context.js#L26
2. https://github.com/getsentry/publish/blob/282135268008c6fc86b7672c71b5fcba233c1dc9/.github/workflows/publish.yml#L29-L31
3. https://github.com/getsentry/publish/blob/282135268008c6fc86b7672c71b5fcba233c1dc9/.github/workflows/publish.yml#L99

The `dry-run` label would be placed on the issue automatically by `getsentry/action-prepare-release` if https://github.com/getsentry/action-prepare-release/pull/43 is merged.

Originated from https://github.com/getsentry/sentry-cocoa/issues/5507