### PR TITLE
fix(targets): Target parser should accept both `x` and `X`

### DIFF
--- a/src/modules/details-from-context.js
+++ b/src/modules/details-from-context.js
@@ -1,7 +1,7 @@
 /**
  * Matches the entire "Targets" section of a github publish issue body.
  */
-const TARGETS_SECTION_PARSER_REGEX = /^(?!### Targets$\s)(?: *- \[[ x]\] \S+\s*$(?:\r?\n)?)+/m;
+const TARGETS_SECTION_PARSER_REGEX = /^(?!### Targets$\s)(?: *- \[[ x]\] \S+\s*$(?:\r?\n)?)+/im;
 
 /**
  * Matches all targets of a github publish issue body in a section that was already matched and extracted with `TARGETS_PARSER_REGEX`.

--- a/src/modules/details-from-context.js
+++ b/src/modules/details-from-context.js
@@ -1,7 +1,7 @@
 /**
  * Matches the entire "Targets" section of a github publish issue body.
  */
-const TARGETS_SECTION_PARSER_REGEX = /^(?!### Targets$\s)(?: *- \[[ x]\] \S+\s*$(?:\r?\n)?)+/im;
+const TARGETS_SECTION_PARSER_REGEX = /^(?!### Targets$\s)(?: *- \[[ xX]\] \S+\s*$(?:\r?\n)?)+/m;
 
 /**
  * Matches all targets of a github publish issue body in a section that was already matched and extracted with `TARGETS_PARSER_REGEX`.


### PR DESCRIPTION
Changes the targets parser to be case insensitive so we handle both `x` and `X` as checked-off.

~~Alternatively, we can make the char-class `[ xX]`.~~

Alternatively we can make the entire regex case-insensitive.

This fixes the issue reported here: https://github.com/getsentry/craft/pull/611#issuecomment-3052962738 (second item)

Related failure: https://github.com/getsentry/publish/issues/5882