### PR TITLE
ci: Run publish action on production

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     name: Publish a new version
     if: github.event.label.name == 'accepted' && github.event.issue.state == 'open'
     timeout-minutes: 90


### PR DESCRIPTION
This change will allow us to give write access to repo once we move all the secrets to the `production` environment as we can restrict environment to the `main` branch only, preventing secret leakage on PRs. We only have the `NPM_TOKEN` moved there and will be testing this before moving over all the secrets, removing them and opening the repo up.

Refs #6422.