### PR TITLE
add sentry-conventions to auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -28,6 +28,7 @@ jobs:
         startsWith(github.event.issue.title, 'publish: getsentry/rust-sourcemap@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/rust-usage-accountant@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/script-runner@') ||
+        startsWith(github.event.issue.title, 'publish: getsentry/sentry-conventions@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-django-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-djangorestframework-stubs@') ||
         startsWith(github.event.issue.title, 'publish: getsentry/sentry-forked-jsonnet@') ||


### PR DESCRIPTION
This is an internal package and teams other than SDKs will want to release it.