### PR TITLE
fix: Resolve undici security vulnerability (CVE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "node": "24.0.0",
     "yarn": "1.22.22"
   },
+  "resolutions": {
+    "undici": "^6.23.0"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,12 +1853,10 @@ undici-types@~7.16.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
-undici@^5.28.5:
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
-  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
+undici@^5.28.5, undici@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz"
+  integrity sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==
 
 universal-user-agent@^6.0.0:
   version "6.0.1"


### PR DESCRIPTION
## Summary

Fixes Dependabot alert #36 (low severity) - unbounded decompression chain in HTTP responses on Node.js Fetch API via Content-Encoding leads to resource exhaustion.

## Changes

- Added yarn `resolutions` to force `undici@^6.23.0` (patched version)
- Updated `yarn.lock` to resolve undici to 6.23.0

## Root Cause

The vulnerable `undici@5.x` was a transitive dependency from `@actions/github` and `@actions/http-client`, which pin to `^5.28.5` and won't accept 6.x without an upstream update.

## Testing

- [ ] CI passes
- [ ] Dependabot alert #36 closes after merge