### PR TITLE
fix: Use GitHub App token in auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -49,7 +49,12 @@ jobs:
         false
       )
     steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@v2.2.1
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
       - run: gh issue edit ${{ github.event.issue.html_url }} --add-label accepted
         env:
-          # can't use `GITHUB_TOKEN` because we need to trigger actions
-          GH_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
## Summary

- Replace the expired/missing `GH_SENTRY_BOT_PAT` secret with a token generated via `actions/create-github-app-token`, using the same `SENTRY_RELEASE_BOT` credentials already used across the org (e.g. [sentry-api-schema](https://github.com/getsentry/sentry-api-schema/blob/fc6e69da/.github/workflows/release.yml#L31-L36)).
- GitHub App tokens trigger downstream workflow runs (unlike `GITHUB_TOKEN`), which is required here since the `accepted` label triggers publish workflows.

Fixes failures like https://github.com/getsentry/publish/actions/runs/21878311288/job/63153355610