### PR TITLE
fix: Add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,6 +2,10 @@ name: auto-approve non-sdks
 on:
   issues:
     types: [opened]
+
+permissions:
+  contents: read
+
 jobs:
   auto-approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Publish
 on:
   issues:
     types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## Summary

- Add least-privilege `permissions` blocks to the 3 workflows flagged by
  CodeQL for `actions/missing-workflow-permissions` (alerts #2, #5, #6).
- `test.yml`: `contents: read` (only checks out code and runs tests)
- `publish.yml`: `contents: read` + `issues: write` (checkout + issue
  comments/labels/close via `GITHUB_TOKEN`; cross-repo ops use the Release
  Bot app token)
- `auto-approve.yml`: `contents: read` (needed for the sparse checkout
  being added in #7119; currently no `GITHUB_TOKEN` write usage)

Resolves all 3 open code-scanning alerts.