### PR TITLE
chore: Add CocoaPod keepalive job

### DIFF
--- a/.github/workflows/cocoapods-keepalive.yml
+++ b/.github/workflows/cocoapods-keepalive.yml
@@ -15,6 +15,7 @@ jobs:
   keepalive:
     name: Refresh CocoaPods Session
     runs-on: macos-15
+    environment: production
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 


### PR DESCRIPTION
Creates a daily job that uses cocoapods token so its expiration time increases.

## Motivation

Cocoapods tokens now expire 3 days after being last used, but we don't want to update them manually every time we make a release.