### PR TITLE
fix: Add packages: write permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: read
   issues: write
+  packages: write
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

- Add `packages: write` to the workflow-level `permissions` block in `publish.yml`

## Problem

Commit `0269363` added explicit least-privilege `permissions` blocks to all workflow files (fixing CodeQL alerts). The `publish.yml` block was set to `contents: read` + `issues: write`, but `packages: write` was omitted.

When an explicit `permissions` block is declared, GitHub treats it as a strict allowlist — `secrets.GITHUB_TOKEN` loses any permissions not listed. This caused Docker pushes to ghcr.io to fail:

```
denied: installation not allowed to Write organization package
```

The `secrets.GITHUB_TOKEN` (passed as `DOCKER_GHCR_IO_PASSWORD`) is the only token that can authenticate to ghcr.io, so it must carry `packages: write`.

## Fix

Add `packages: write` to the permissions block. No changes to Craft or any other files needed.

Fixes https://github.com/getsentry/publish/actions/runs/22119619739 and https://github.com/getsentry/publish/actions/runs/22119618913