### PR TITLE
chore(workflow): Replace git user info with sentry-release-bot

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,9 +105,9 @@ jobs:
           CRAFT_MERGE_TARGET: ${{ fromJSON(steps.inputs.outputs.result).merge_target }}
           CRAFT_LOG_LEVEL: ${{ vars.CRAFT_LOG_LEVEL || 'Info' }}
           CRAFT_DRY_RUN: ${{ fromJSON(steps.inputs.outputs.result).dry_run }}
-          GIT_COMMITTER_NAME: getsentry-bot
-          GIT_AUTHOR_NAME: getsentry-bot
-          EMAIL: bot@getsentry.com
+          GIT_COMMITTER_NAME: sentry-release-bot[bot]
+          GIT_AUTHOR_NAME: sentry-release-bot[bot]
+          EMAIL: 180476844+sentry-release-bot[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           # We need to use separate tokens for GHCR.IO and GitHub API access
           # Because we can only access ghcr.io with GITHUB_TOKEN but that token


### PR DESCRIPTION
The workflow is using a token from the [sentry-release-bot](https://github.com/apps/sentry-release-bot) already, but the git commit and author info is still using `getsentry-bot` which is confusing.
Updating it so that everything is aligned