### PR TITLE
fix(workflow): add GH_TOKEN to gh CLI steps and split variable/label auth

### DIFF
--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -21,13 +21,20 @@ jobs:
           app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      - name: Add ci-pending label and enable poller
+      - name: Add ci-pending label
         env:
+          # Use the app token so the label event triggers publish.yml
+          # (GITHUB_TOKEN events are suppressed by GitHub).
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh issue edit "${{ github.event.issue.number }}" \
             -R "$GITHUB_REPOSITORY" \
             --add-label "ci-pending"
 
-          # Enable the cron poller (ci-poller.yml) so it starts checking
+      - name: Enable cron poller
+        env:
+          # Use GITHUB_TOKEN (with actions:write) for variable access —
+          # the app token may not have the actions_variables permission.
+          GH_TOKEN: ${{ github.token }}
+        run: |
           gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "true"

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -28,6 +28,7 @@ jobs:
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Check CI status for ci-pending issues
+        id: check
         env:
           # Use the app token so label changes trigger publish.yml
           # (GITHUB_TOKEN events are suppressed by GitHub).
@@ -42,8 +43,7 @@ jobs:
 
           count=$(echo "$issues" | jq length)
           if [[ "$count" == "0" ]]; then
-            echo "No ci-pending issues found. Disabling poller."
-            gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "false"
+            echo "No ci-pending issues found."
             exit 0
           fi
           echo "Found ${count} ci-pending issue(s)."
@@ -140,11 +140,17 @@ jobs:
             fi
           done
 
-          # Re-check if there are still pending issues; disable poller if none remain.
-          # Note: there's a small race window where ci-pending.yml could set the
-          # variable to "true" right before we set it to "false" here. In that case
-          # the new issue waits at most one cron tick (5 min) — ci-pending.yml will
-          # set the variable again on the next issue:opened event if needed.
+      # Disable the poller if no ci-pending issues remain. Uses GITHUB_TOKEN
+      # (with actions:write) since the app token may lack actions_variables
+      # permission.
+      # Note: there's a small race window where ci-pending.yml could set the
+      # variable to "true" right before we set it to "false" here. In that case
+      # the new issue waits at most one cron tick (5 min) — ci-pending.yml will
+      # set the variable again on the next issue:opened event if needed.
+      - name: Disable poller if no pending issues remain
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
           remaining=$(gh issue list -R "$GITHUB_REPOSITORY" \
             --state open \
             --label ci-pending \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
       && contains(github.event.issue.labels.*.name, 'ci-pending')
     steps:
       - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh issue comment "${{ github.event.issue.number }}" \
             -R "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary

Fix CI poller and waiting-for-ci workflows failing because:
1. `gh` CLI requires `GH_TOKEN` to be set explicitly in GitHub Actions
2. `GITHUB_TOKEN` cannot write repo variables — returns 403 "Resource not accessible by integration"

Failing runs:
- https://github.com/getsentry/publish/actions/runs/24251134122/job/70810504705
- https://github.com/getsentry/publish/actions/runs/24263308562/job/70852292016

## Changes

- **`publish.yml`**: Add `GH_TOKEN: ${{ github.token }}` to `waiting-for-ci` comment step
- **`ci-pending.yml`**: Split into two steps — label change and variable set both use app token
- **`ci-poller.yml`**: Same split — variable disable step uses app token instead of `GITHUB_TOKEN`
- Remove unnecessary `actions: write` permission (not needed when using app token)