### PR TITLE
fix(workflow): use app token for gh variable set — GITHUB_TOKEN lacks permission

### DIFF
--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   issues: read
-  actions: write
 
 jobs:
   mark-pending:
@@ -33,8 +32,8 @@ jobs:
 
       - name: Enable cron poller
         env:
-          # Use GITHUB_TOKEN (with actions:write) for variable access —
-          # the app token may not have the actions_variables permission.
-          GH_TOKEN: ${{ github.token }}
+          # Use the app token — GITHUB_TOKEN cannot write repo variables
+          # (403 "Resource not accessible by integration").
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "true"

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   issues: read
-  actions: write
 
 jobs:
   check-ci:
@@ -140,16 +139,16 @@ jobs:
             fi
           done
 
-      # Disable the poller if no ci-pending issues remain. Uses GITHUB_TOKEN
-      # (with actions:write) since the app token may lack actions_variables
-      # permission.
+      # Disable the poller if no ci-pending issues remain.
       # Note: there's a small race window where ci-pending.yml could set the
       # variable to "true" right before we set it to "false" here. In that case
       # the new issue waits at most one cron tick (5 min) — ci-pending.yml will
       # set the variable again on the next issue:opened event if needed.
       - name: Disable poller if no pending issues remain
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use the app token — GITHUB_TOKEN cannot write repo variables
+          # (403 "Resource not accessible by integration").
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           remaining=$(gh issue list -R "$GITHUB_REPOSITORY" \
             --state open \


### PR DESCRIPTION
## Summary

Two fixes for the CI status poller:

### 1. Use app token for `gh variable set`
`GITHUB_TOKEN` cannot write repo variables — returns 403 "Resource not accessible by integration" even with `actions: write`.

Failing run: https://github.com/getsentry/publish/actions/runs/24263308562/job/70852292016

### 2. Resolve release branch HEAD instead of stale issue SHA
When a bot pushes a new commit to the release branch after issue creation, the "View check runs" SHA in the issue body is stale. The poller checks CI on the old commit and never sees the new CI results.

Failing run: https://github.com/getsentry/publish/actions/runs/24264032659/job/70854676310

**Fix:** Use the Check Suites API to discover the branch name from the original SHA (`check_suites[0].head_branch`), then resolve the branch HEAD via `git/ref/heads/{branch}`. If it moved, update the issue body so the link stays accurate for humans and future poller runs.

Fallback: if check suites return nothing, use the issue body SHA as before.

## Changes

- `ci-pending.yml`: Use app token for `gh variable set`
- `ci-poller.yml`: Use app token for `gh variable set`; resolve branch HEAD dynamically; update stale issue links
- `ci-poller.yml`, `ci-pending.yml`: Remove unnecessary `actions: write` permission