### PR TITLE
fix(workflow): resolve release branch HEAD instead of using stale issue SHA

### DIFF
--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -64,13 +64,44 @@ jobs:
             fi
 
             # Extract the commit SHA from the "View check runs" link in the issue body.
-            # The link format is: https://github.com/{owner}/{repo}/commit/{SHA}/checks/
-            # This avoids hard-coding the release branch name, which repos can customize.
-            sha=$(echo "$body" | grep -oP '(?<=commit/)[0-9a-f]{40}(?=/checks)' || true)
+            # Link format: https://github.com/{owner}/{repo}/commit/{SHA}/checks/
+            issue_sha=$(echo "$body" | grep -oP '(?<=commit/)[0-9a-f]{40}(?=/checks)' || true)
 
-            if [[ -z "$sha" ]]; then
+            if [[ -z "$issue_sha" ]]; then
               echo "::warning::Could not extract commit SHA from issue #${number} body, skipping."
               continue
+            fi
+
+            # Resolve the release branch name from the original commit's check
+            # suites (avoids hard-coding "release/{version}" since repos can
+            # customize branch names in their craft config).
+            branch=$(gh api "repos/${repo}/commits/${issue_sha}/check-suites" \
+              --jq '.check_suites[0].head_branch // empty' 2>/dev/null || true)
+
+            if [[ -n "$branch" ]]; then
+              # Resolve the branch HEAD — may differ from issue_sha if a bot
+              # (e.g., auto-fix, skill regeneration) pushed a new commit.
+              head_sha=$(gh api "repos/${repo}/git/ref/heads/${branch}" \
+                --jq '.object.sha' 2>/dev/null || true)
+
+              if [[ -n "$head_sha" ]]; then
+                sha="$head_sha"
+              else
+                echo "  Could not resolve HEAD of ${branch}, using issue SHA."
+                sha="$issue_sha"
+              fi
+            else
+              echo "  No check suites found for ${issue_sha:0:8}, using issue SHA."
+              sha="$issue_sha"
+            fi
+
+            # If the branch moved (bot pushed a new commit), update the
+            # "View check runs" link in the issue body so it stays accurate
+            # for humans and for subsequent poller runs.
+            if [[ "$sha" != "$issue_sha" ]]; then
+              echo "  Branch ${branch} moved: ${issue_sha:0:8} → ${sha:0:8}. Updating issue."
+              updated_body="${body//${issue_sha}/${sha}}"
+              gh issue edit "$number" -R "$GITHUB_REPOSITORY" --body "$updated_body"
             fi
 
             echo "Checking CI for ${repo}@${version} commit ${sha:0:8} (issue #${number})..."
@@ -113,7 +144,7 @@ jobs:
             #   - commit status is "success" or no statuses were reported (some
             #     repos use only check runs, not commit statuses)
             #   - all check runs are completed (none pending)
-            #   - no check runs have failed
+            #   - no check runs have unsuccessful conclusions
             status_ok=false
             if [[ "$commit_status" == "success" ]]; then
               status_ok=true


### PR DESCRIPTION
## Summary

When a bot (e.g., auto-fix, skill regeneration) pushes a new commit to the release branch after the publish issue is created, the "View check runs" SHA in the issue body becomes stale. The CI poller checks status on the old commit and never sees the new CI results.

Failing run: https://github.com/getsentry/publish/actions/runs/24264032659/job/70854676310

## Fix

Use the Check Suites API to discover the branch name from the original SHA (`check_suites[0].head_branch`), then resolve the branch HEAD via `git/ref/heads/{branch}`. This avoids assuming any branch naming convention.

If the branch HEAD differs from the issue SHA, update the issue body so the "View check runs" link stays accurate for humans and subsequent poller runs.

Fallback: if check suites return no results, use the issue body SHA as before.