### PR TITLE
fix(workflow): bump create-github-app-token v2 → v3 (Node.js 24)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -19,7 +19,7 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@v2.2.1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@v2.2.1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@v2.2.1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Get Release Bot auth token
         id: token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Bump `actions/create-github-app-token` from v2 to v3 across all workflow files to resolve the Node.js 20 deprecation warning.

> Node.js 24 will be forced starting June 2, 2026. Node.js 20 removed from runners September 16, 2026.

## Files changed

- `publish.yml` (was pinned to SHA `@29824e69...` with `# v2` comment)
- `ci-pending.yml` (`@v2.2.1`)
- `ci-poller.yml` (`@v2.2.1`)
- `auto-approve.yml` (`@v2.2.1`)

## Breaking changes in v3 (no impact)

- Proxy support now requires `NODE_USE_ENV_PROXY=1` — not used in this repo
- Requires Actions Runner v2.327.1+ for self-hosted runners — N/A (GitHub-hosted)