### PR TITLE
fix(workflow): drop repo variable gate, use cheap GITHUB_TOKEN check instead

### DIFF
--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -29,11 +29,3 @@ jobs:
           gh issue edit "${{ github.event.issue.number }}" \
             -R "$GITHUB_REPOSITORY" \
             --add-label "ci-pending"
-
-      - name: Enable cron poller
-        env:
-          # Use the app token — GITHUB_TOKEN cannot write repo variables
-          # (403 "Resource not accessible by integration").
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "true"

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -11,15 +11,29 @@ permissions:
 jobs:
   check-ci:
     runs-on: ubuntu-latest
-    # Skip entirely (no runner provisioned) when there's nothing to check.
-    # The CI_POLLER_HAS_PENDING variable is set to "true" by ci-pending.yml
-    # and reset to "false" here when all pending issues are resolved.
-    if: vars.CI_POLLER_HAS_PENDING == 'true'
     concurrency:
       group: ci-status-poller
       cancel-in-progress: false
     steps:
+      # Cheap first check with GITHUB_TOKEN — if no ci-pending issues exist,
+      # exit immediately without generating an app token (~5s idle cost).
+      - name: Check for pending issues
+        id: pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh issue list -R "$GITHUB_REPOSITORY" \
+            --state open \
+            --label ci-pending \
+            --limit 1 \
+            --json number -q 'length')
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          if [[ "$count" == "0" ]]; then
+            echo "No ci-pending issues. Nothing to do."
+          fi
+
       - name: Get auth token
+        if: steps.pending.outputs.count != '0'
         id: token
         uses: actions/create-github-app-token@v3
         with:
@@ -27,7 +41,7 @@ jobs:
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Check CI status for ci-pending issues
-        id: check
+        if: steps.pending.outputs.count != '0'
         env:
           # Use the app token so label changes trigger publish.yml
           # (GITHUB_TOKEN events are suppressed by GitHub).
@@ -41,10 +55,6 @@ jobs:
             --json number,title,labels,body)
 
           count=$(echo "$issues" | jq length)
-          if [[ "$count" == "0" ]]; then
-            echo "No ci-pending issues found."
-            exit 0
-          fi
           echo "Found ${count} ci-pending issue(s)."
 
           # Check each issue's CI status
@@ -169,24 +179,3 @@ jobs:
               gh issue comment "$number" -R "$GITHUB_REPOSITORY" --body "$comment"
             fi
           done
-
-      # Disable the poller if no ci-pending issues remain.
-      # Note: there's a small race window where ci-pending.yml could set the
-      # variable to "true" right before we set it to "false" here. In that case
-      # the new issue waits at most one cron tick (5 min) — ci-pending.yml will
-      # set the variable again on the next issue:opened event if needed.
-      - name: Disable poller if no pending issues remain
-        env:
-          # Use the app token — GITHUB_TOKEN cannot write repo variables
-          # (403 "Resource not accessible by integration").
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          remaining=$(gh issue list -R "$GITHUB_REPOSITORY" \
-            --state open \
-            --label ci-pending \
-            --limit 1 \
-            --json number -q 'length')
-          if [[ "$remaining" == "0" ]]; then
-            echo "All ci-pending issues resolved. Disabling poller."
-            gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "false"
-          fi


### PR DESCRIPTION
## Summary

Replace the `CI_POLLER_HAS_PENDING` repo variable gate with a cheap `GITHUB_TOKEN` issue list check as the first step. Fixes the 403 errors from `gh variable set`.

## Why

Neither `GITHUB_TOKEN` nor the sentry-internal-app token has the `actions_variables:write` permission needed to write repo variables. Rather than requesting a new permission on the app, use a simpler approach.

## How it works now

**`ci-poller.yml` (cron every 5 min):**
1. First step: `gh issue list --label ci-pending` with `GITHUB_TOKEN` (~5 seconds)
2. If count is 0 → exit. No app token generated, minimal cost.
3. If count > 0 → generate app token, check CI status, flip labels

**`ci-pending.yml` (issues:opened):**
1. Generate app token, add `ci-pending` label — that's it. No variable set.

## Cost

- **Idle (no pending releases):** ~5-10 seconds per cron tick (one API call + exit). No app token generated.
- **Active:** same as before — check CI status, flip labels when green.