### PR TITLE
fix(workflow): handle monorepo paths in title parsing and fix app-id deprecation

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,7 +21,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          client-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
       - name: Auto-approve if repo is in the list
         env:

--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -17,7 +17,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          client-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Add ci-pending label

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -37,7 +37,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          client-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Check CI status for ci-pending issues
@@ -64,8 +64,11 @@ jobs:
             body=$(echo "$issue" | jq -r '.body')
             has_accepted=$(echo "$issue" | jq '[.labels[].name] | any(. == "accepted")')
 
-            # Parse repo and version from title: "publish: owner/repo@version"
-            repo=$(echo "$title" | sed -n 's/^publish: \(.*\)@.*/\1/p')
+            # Parse repo and version from title: "publish: owner/repo[/path]@version"
+            # Only take owner/repo (first two segments) — monorepos like
+            # "getsentry/relay/py@0.9.26" have a path suffix that isn't part
+            # of the GitHub repo name.
+            repo=$(echo "$title" | sed -n 's|^publish: \([^/]*/[^/@]*\).*@.*|\1|p')
             version=$(echo "$title" | sed -n 's/^publish: .*@\(.*\)/\1/p')
 
             if [[ -z "$repo" || -z "$version" ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          client-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
           owner: getsentry # create token that have access to all repos
 


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Monorepo title parsing (causes CI poller to 404)

The repo parser extracted the full path from monorepo issue titles, e.g., `publish: getsentry/relay/py@0.9.26` → `getsentry/relay/py`. API calls to `repos/getsentry/relay/py/...` returned 404, so the poller could never detect CI completion.

Fix: only extract `owner/repo` (first two path segments). `getsentry/relay/py` → `getsentry/relay`.

Failing run: https://github.com/getsentry/publish/actions/runs/24335600870/job/71053497008

### 2. Deprecated `app-id` input

Replace `app-id` with `client-id` on `actions/create-github-app-token@v3` across all workflow files.

### Re: irregular cron timing

GitHub Actions cron is not guaranteed to run on time — from the docs: "The schedule event can be delayed during periods of high loads." This is expected behavior and not something we can fix.