### PR TITLE
feat(workflow): restore repo variable gate with dedicated poller app

### DIFF
--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -21,13 +21,9 @@ jobs:
           client-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      - name: Get poller app token
-        id: poller-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
-
+      # Add the label first — this is the critical step. The poller
+      # token and variable set below are best-effort optimizations
+      # that must not block label addition.
       - name: Add ci-pending label
         env:
           # Use the app token so the label event triggers publish.yml
@@ -37,6 +33,13 @@ jobs:
           gh issue edit "${{ github.event.issue.number }}" \
             -R "$GITHUB_REPOSITORY" \
             --add-label "ci-pending"
+
+      - name: Get poller app token
+        id: poller-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
 
       - name: Enable cron poller
         env:

--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   mark-pending:
     runs-on: ubuntu-latest
+    environment: production
     if: "startsWith(github.event.issue.title, 'publish: ')"
     steps:
       - name: Get auth token
@@ -19,6 +20,13 @@ jobs:
         with:
           client-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+      - name: Get poller app token
+        id: poller-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
 
       - name: Add ci-pending label
         env:
@@ -29,3 +37,9 @@ jobs:
           gh issue edit "${{ github.event.issue.number }}" \
             -R "$GITHUB_REPOSITORY" \
             --add-label "ci-pending"
+
+      - name: Enable cron poller
+        env:
+          GH_TOKEN: ${{ steps.poller-token.outputs.token }}
+        run: |
+          gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "true"

--- a/.github/workflows/ci-pending.yml
+++ b/.github/workflows/ci-pending.yml
@@ -34,14 +34,19 @@ jobs:
             -R "$GITHUB_REPOSITORY" \
             --add-label "ci-pending"
 
+      # Best-effort: enable the cron poller variable. If this fails, the
+      # poller's cron will still pick up the issue (it just won't skip the
+      # runner provisioning on idle ticks until the variable is set).
       - name: Get poller app token
         id: poller-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
 
       - name: Enable cron poller
+        if: steps.poller-token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.poller-token.outputs.token }}
         run: |

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -205,7 +205,7 @@ jobs:
       # our check and our set-to-false. Worst case: the new issue waits one
       # cron tick (5 min). ci-pending.yml will re-enable on the next opened event.
       - name: Disable poller if no pending issues remain
-        if: always() && steps.remaining.outputs.count == '0'
+        if: always() && steps.remaining.outputs.count == '0' && steps.poller-token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.poller-token.outputs.token }}
         run: |

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -15,7 +15,8 @@ jobs:
     environment: production
     # Skip entirely (no runner provisioned) when there's nothing to check.
     # Set to "true" by ci-pending.yml, reset to "false" here when done.
-    if: vars.CI_POLLER_HAS_PENDING == 'true'
+    # Always allow workflow_dispatch for manual recovery.
+    if: vars.CI_POLLER_HAS_PENDING == 'true' || github.event_name == 'workflow_dispatch'
     concurrency:
       group: ci-status-poller
       cancel-in-progress: false
@@ -197,6 +198,9 @@ jobs:
           echo "count=${count}" >> "$GITHUB_OUTPUT"
 
       # Disable the poller if no ci-pending issues remain.
+      # Race window: ci-pending.yml could set the variable to "true" between
+      # our check and our set-to-false. Worst case: the new issue waits one
+      # cron tick (5 min). ci-pending.yml will re-enable on the next opened event.
       - name: Disable poller if no pending issues remain
         if: steps.remaining.outputs.count == '0'
         env:

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -190,24 +190,28 @@ jobs:
             --json number -q 'length')
           echo "count=${count}" >> "$GITHUB_OUTPUT"
 
-      # Get the poller app token only when we need to disable the variable.
-      # Placed here (after CI check) so a token failure can't block CI checking.
+      # Update the poller variable to match reality:
+      # - Remaining issues → ensure variable is "true" (important when
+      #   workflow_dispatch bypassed the gate while variable was "false")
+      # - No remaining issues → set to "false" to stop the cron
+      # Placed after CI check so a token failure can't block CI checking.
       - name: Get poller app token
-        if: always() && steps.remaining.outputs.count == '0'
+        if: always()
         id: poller-token
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
 
-      # Disable the poller if no ci-pending issues remain.
-      # Race window: ci-pending.yml could set the variable to "true" between
-      # our check and our set-to-false. Worst case: the new issue waits one
-      # cron tick (5 min). ci-pending.yml will re-enable on the next opened event.
-      - name: Disable poller if no pending issues remain
-        if: always() && steps.remaining.outputs.count == '0' && steps.poller-token.outcome == 'success'
+      - name: Sync poller variable with pending issue state
+        if: always() && steps.poller-token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.poller-token.outputs.token }}
         run: |
-          echo "All ci-pending issues resolved. Disabling poller."
-          gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "false"
+          if [[ "${{ steps.remaining.outputs.count }}" == "0" ]]; then
+            echo "All ci-pending issues resolved. Disabling poller."
+            gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "false"
+          else
+            echo "Still pending issues. Ensuring poller stays enabled."
+            gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "true"
+          fi

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -3,6 +3,7 @@ name: CI Status Poller
 on:
   schedule:
     - cron: "*/5 * * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -11,37 +11,31 @@ permissions:
 jobs:
   check-ci:
     runs-on: ubuntu-latest
+    environment: production
+    # Skip entirely (no runner provisioned) when there's nothing to check.
+    # Set to "true" by ci-pending.yml, reset to "false" here when done.
+    if: vars.CI_POLLER_HAS_PENDING == 'true'
     concurrency:
       group: ci-status-poller
       cancel-in-progress: false
     steps:
-      # Cheap first check with GITHUB_TOKEN — if no ci-pending issues exist,
-      # exit immediately without generating an app token (~5s idle cost).
-      - name: Check for pending issues
-        id: pending
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          count=$(gh issue list -R "$GITHUB_REPOSITORY" \
-            --state open \
-            --label ci-pending \
-            --limit 1 \
-            --json number -q 'length')
-          echo "count=${count}" >> "$GITHUB_OUTPUT"
-          if [[ "$count" == "0" ]]; then
-            echo "No ci-pending issues. Nothing to do."
-          fi
-
       - name: Get auth token
-        if: steps.pending.outputs.count != '0'
         id: token
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
+      # Separate app token for writing repo variables — the sentry-internal
+      # app lacks the actions_variables permission.
+      - name: Get poller app token
+        id: poller-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
+
       - name: Check CI status for ci-pending issues
-        if: steps.pending.outputs.count != '0'
         env:
           # Use the app token so label changes trigger publish.yml
           # (GITHUB_TOKEN events are suppressed by GitHub).
@@ -55,6 +49,10 @@ jobs:
             --json number,title,labels,body)
 
           count=$(echo "$issues" | jq length)
+          if [[ "$count" == "0" ]]; then
+            echo "No ci-pending issues found."
+            exit 0
+          fi
           echo "Found ${count} ci-pending issue(s)."
 
           # Check each issue's CI status
@@ -182,3 +180,18 @@ jobs:
               gh issue comment "$number" -R "$GITHUB_REPOSITORY" --body "$comment"
             fi
           done
+
+      # Disable the poller if no ci-pending issues remain.
+      - name: Disable poller if no pending issues remain
+        env:
+          GH_TOKEN: ${{ steps.poller-token.outputs.token }}
+        run: |
+          remaining=$(gh issue list -R "$GITHUB_REPOSITORY" \
+            --state open \
+            --label ci-pending \
+            --limit 1 \
+            --json number -q 'length')
+          if [[ "$remaining" == "0" ]]; then
+            echo "All ci-pending issues resolved. Disabling poller."
+            gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "false"
+          fi

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -182,17 +182,25 @@ jobs:
             fi
           done
 
-      # Disable the poller if no ci-pending issues remain.
-      - name: Disable poller if no pending issues remain
+      # Check if any ci-pending issues remain (using GITHUB_TOKEN for
+      # read access — the poller app may only have actions_variables).
+      - name: Check for remaining pending issues
+        id: remaining
         env:
-          GH_TOKEN: ${{ steps.poller-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          remaining=$(gh issue list -R "$GITHUB_REPOSITORY" \
+          count=$(gh issue list -R "$GITHUB_REPOSITORY" \
             --state open \
             --label ci-pending \
             --limit 1 \
             --json number -q 'length')
-          if [[ "$remaining" == "0" ]]; then
-            echo "All ci-pending issues resolved. Disabling poller."
-            gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "false"
-          fi
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+
+      # Disable the poller if no ci-pending issues remain.
+      - name: Disable poller if no pending issues remain
+        if: steps.remaining.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ steps.poller-token.outputs.token }}
+        run: |
+          echo "All ci-pending issues resolved. Disabling poller."
+          gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "false"

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -28,15 +28,6 @@ jobs:
           client-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      # Separate app token for writing repo variables — the sentry-internal
-      # app lacks the actions_variables permission.
-      - name: Get poller app token
-        id: poller-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
-
       - name: Check CI status for ci-pending issues
         env:
           # Use the app token so label changes trigger publish.yml
@@ -183,9 +174,11 @@ jobs:
             fi
           done
 
-      # Check if any ci-pending issues remain (using GITHUB_TOKEN for
-      # read access — the poller app may only have actions_variables).
+      # Cleanup: check if we should disable the poller. Runs even if the
+      # CI check step above failed, so CI_POLLER_HAS_PENDING doesn't get
+      # stuck on "true" permanently.
       - name: Check for remaining pending issues
+        if: always()
         id: remaining
         env:
           GH_TOKEN: ${{ github.token }}
@@ -197,12 +190,22 @@ jobs:
             --json number -q 'length')
           echo "count=${count}" >> "$GITHUB_OUTPUT"
 
+      # Get the poller app token only when we need to disable the variable.
+      # Placed here (after CI check) so a token failure can't block CI checking.
+      - name: Get poller app token
+        if: always() && steps.remaining.outputs.count == '0'
+        id: poller-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.CI_POLLER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_POLLER_APP_PRIVATE_KEY }}
+
       # Disable the poller if no ci-pending issues remain.
       # Race window: ci-pending.yml could set the variable to "true" between
       # our check and our set-to-false. Worst case: the new issue waits one
       # cron tick (5 min). ci-pending.yml will re-enable on the next opened event.
       - name: Disable poller if no pending issues remain
-        if: steps.remaining.outputs.count == '0'
+        if: always() && steps.remaining.outputs.count == '0'
         env:
           GH_TOKEN: ${{ steps.poller-token.outputs.token }}
         run: |


### PR DESCRIPTION
## Summary

Bring back the `CI_POLLER_HAS_PENDING` variable gate so the cron is truly zero-cost when idle — no runner provisioned at all.

Uses a dedicated GitHub App (`CI_POLLER_APP_CLIENT_ID`) for variable writes since neither `GITHUB_TOKEN` nor sentry-internal-app has the `actions_variables:write` permission. The app secret is in the `production` environment for branch protection.

## How it works

| Workflow | Trigger | What it does |
|---|---|---|
| `ci-pending.yml` | `issues: opened` | Adds `ci-pending` label (sentry-internal-app) + sets variable to `true` (poller app) |
| `ci-poller.yml` | `schedule: */5` | `if: vars.CI_POLLER_HAS_PENDING == 'true'` — skips when false (no runner). Checks CI, flips labels, sets variable to `false` when done. |

## Cost

- **Idle:** zero — job `if` is false, no runner provisioned
- **Active:** ~30s per cron tick while there are pending releases
- **Previous (without variable):** ~10-15s per tick 24/7 even when idle

## Pre-requisites (already done)

- Repo variable: `CI_POLLER_HAS_PENDING` = `false`
- Repo variable: `CI_POLLER_APP_CLIENT_ID`
- Production environment secret: `CI_POLLER_APP_PRIVATE_KEY`