### PR TITLE
fix(ci-poller): handle commit-status failures when all check runs pass

### DIFF
--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -188,8 +188,10 @@ jobs:
                 echo "  CI failed (already commented for this SHA)."
               fi
 
-            elif [[ "$status_ok" == "false" && "$pending_checks" == "0" && "$unsuccessful_checks" == "0" ]]; then
-              # All check runs passed but commit statuses reported a failure
+            elif [[ "$commit_status" == "failure" && "$pending_checks" == "0" && "$unsuccessful_checks" == "0" ]]; then
+              # All check runs passed but commit statuses reported a failure.
+              # Note: we check for "failure" explicitly, not just !status_ok,
+              # because "pending" statuses should fall through to retry next tick.
               marker="<!-- ci-failure-${sha} -->"
               existing=$(gh issue view "$number" -R "$GITHUB_REPOSITORY" \
                 --json comments -q "[.comments[].body | select(contains(\"${marker}\"))] | length" 2>/dev/null || echo "0")

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -192,7 +192,7 @@ jobs:
               # All check runs passed but commit statuses reported a failure.
               # Note: we check for "failure" explicitly, not just !status_ok,
               # because "pending" statuses should fall through to retry next tick.
-              marker="<!-- ci-failure-${sha} -->"
+              marker="<!-- ci-status-failure-${sha} -->"
               existing=$(gh issue view "$number" -R "$GITHUB_REPOSITORY" \
                 --json comments -q "[.comments[].body | select(contains(\"${marker}\"))] | length" 2>/dev/null || echo "0")
 
@@ -200,7 +200,7 @@ jobs:
                 echo "  CI failed (commit status). Commenting on issue."
                 failed_contexts=$(gh api "repos/${repo}/commits/${sha}/status" \
                   --jq '[.statuses[] | select(.state == "failure" or .state == "error")] | map(.context + " (" + .state + ")") | join(", ")')
-                body="${marker}"$'\n'"CI checks **failed** for ${repo}@${version} (\`${sha:0:8}\`). Publishing is blocked until CI passes."$'\n\n'"Failed status checks: ${failed_contexts}"$'\n\n'"[View check runs](https://github.com/${repo}/commit/${sha}/checks/)"
+                body="${marker}"$'\n'"CI **commit status** checks failed for ${repo}@${version} (\`${sha:0:8}\`). Publishing is blocked until CI passes."$'\n\n'"Failed status checks: ${failed_contexts}"$'\n\n'"[View check runs](https://github.com/${repo}/commit/${sha}/checks/)"
                 gh issue comment "$number" -R "$GITHUB_REPOSITORY" --body "$body"
               else
                 echo "  CI failed via commit status (already commented for this SHA)."

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -187,6 +187,22 @@ jobs:
               else
                 echo "  CI failed (already commented for this SHA)."
               fi
+
+            elif [[ "$status_ok" == "false" && "$pending_checks" == "0" && "$unsuccessful_checks" == "0" ]]; then
+              # All check runs passed but commit statuses reported a failure
+              marker="<!-- ci-failure-${sha} -->"
+              existing=$(gh issue view "$number" -R "$GITHUB_REPOSITORY" \
+                --json comments -q "[.comments[].body | select(contains(\"${marker}\"))] | length" 2>/dev/null || echo "0")
+
+              if [[ "$existing" == "0" ]]; then
+                echo "  CI failed (commit status). Commenting on issue."
+                failed_contexts=$(gh api "repos/${repo}/commits/${sha}/status" \
+                  --jq '[.statuses[] | select(.state == "failure" or .state == "error")] | map(.context + " (" + .state + ")") | join(", ")')
+                body="${marker}"$'\n'"CI checks **failed** for ${repo}@${version} (\`${sha:0:8}\`). Publishing is blocked until CI passes."$'\n\n'"Failed status checks: ${failed_contexts}"$'\n\n'"[View check runs](https://github.com/${repo}/commit/${sha}/checks/)"
+                gh issue comment "$number" -R "$GITHUB_REPOSITORY" --body "$body"
+              else
+                echo "  CI failed via commit status (already commented for this SHA)."
+              fi
             fi
           done
 


### PR DESCRIPTION
The poller silently ignored commit-status failures (e.g. console compat checks) because the failure branch only checked for unsuccessful check runs. This left publish issues stuck as ci-pending with no comment.

From `sentry-native` we added these checks in our console repos that report back with a commit status (e.g. [sentry-switch](https://github.com/getsentry/sentry-switch/actions/runs/24468542398/job/71504743073#step:3:33)) , but since all actual check-runs in [sentry-native CI](https://github.com/getsentry/sentry-native/actions/runs/24468536557) passed, the CI status poller doesn't finish since it's waiting for `status_ok` to become true (or some CI check to be unsuccessful, which they are not).

## Analysis
The following flowgraph shows the existing paths, and the new path (added in purple). Before, we would just end up in the orange state, stuck in `ci-pending` (see https://github.com/getsentry/publish/issues/7819), since we'd never reach any of the other terminal states.

```mermaid
flowchart TD
    A[Start: process issue] --> B{total_checks == 0<br/>AND total_statuses == 0?}
    B -->|Yes| C[No CI found yet — skip]
    B -->|No| D{commit_status == success?}

    D -->|Yes| E[status_ok = true]
    D -->|No| F{total_statuses == 0?}
    F -->|Yes| G[status_ok = true<br/>repo uses only check runs]
    F -->|No| H[status_ok = false]

    E --> I{status_ok == true<br/>AND pending == 0<br/>AND unsuccessful == 0?}
    G --> I

    I -->|Yes| J[✅ CI passed<br/>Add ci-ready label<br/>Comment on issue]

    I -->|No| K{pending == 0<br/>AND unsuccessful != 0?}
    H --> K

    K -->|Yes| L[❌ Check-run failure<br/>Comment with failed check names]
    K -->|No| N{commit_status == failure<br/>AND pending == 0<br/>AND unsuccessful == 0?}
    N -->|Yes| P[❌ Commit-status failure<br/>Comment with failed status contexts]
    N -->|No| M[⏳ Still pending<br/>— silent, retry next tick]

    style J fill:#2ecc71,stroke:#27ae60,color:#fff
    style L fill:#e74c3c,stroke:#c0392b,color:#fff
    style M fill:#f39c12,stroke:#e67e22,color:#fff
    style C fill:#95a5a6,stroke:#7f8c8d,color:#fff

    style P fill:#9b59b6,stroke:#6c3483,color:#fff,stroke-width:4px
    style N fill:#d2b4de,stroke:#6c3483,color:#000,stroke-width:3px

    linkStyle 13 stroke:#9b59b6,stroke-width:3px
    linkStyle 14 stroke:#9b59b6,stroke-width:3px


```