### PR TITLE
feat(workflow): self-dispatch poller for fast CI checking (~30-60s intervals)

### DIFF
--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -256,7 +256,10 @@ jobs:
       # fallback continues checking and the chain restarts on the next
       # manual trigger (accepted label re-added or workflow_dispatch).
       - name: Self-dispatch if issues remain pending
-        if: always() && steps.remaining.outputs.count != '0'
+        if: >-
+          always()
+          && steps.remaining.outcome == 'success'
+          && steps.remaining.outputs.count != '0'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           ATTEMPT: ${{ github.event.inputs.attempt || '0' }}
@@ -266,5 +269,5 @@ jobs:
             echo "::warning::Max self-dispatch attempts (60) reached. Relying on cron fallback."
             exit 0
           fi
-          echo "Re-dispatching (attempt ${attempt}/360)..."
+          echo "Re-dispatching (attempt ${attempt}/60)..."
           gh workflow run ci-poller.yml -R "$GITHUB_REPOSITORY" -f attempt="${attempt}"

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -258,6 +258,7 @@ jobs:
       - name: Self-dispatch if issues remain pending
         if: >-
           always()
+          && steps.token.outcome == 'success'
           && steps.remaining.outcome == 'success'
           && steps.remaining.outputs.count != '0'
         env:

--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
+    inputs:
+      attempt:
+        description: Self-dispatch attempt counter (internal use)
+        required: false
+        default: "0"
 
 permissions:
   contents: read
@@ -242,3 +247,24 @@ jobs:
             echo "Still pending issues. Ensuring poller stays enabled."
             gh variable set CI_POLLER_HAS_PENDING -R "$GITHUB_REPOSITORY" -b "true"
           fi
+
+      # Self-dispatch for fast re-checking when issues are still pending.
+      # GitHub's cron is unreliable (*/5 can drift to 30-40 min under load).
+      # Self-dispatch gives ~30-60s between checks via GHA startup latency.
+      # The concurrency group prevents accumulation (1 running + 1 queued).
+      # Cap at 60 attempts (~30 min). If CI hasn't passed by then, the cron
+      # fallback continues checking and the chain restarts on the next
+      # manual trigger (accepted label re-added or workflow_dispatch).
+      - name: Self-dispatch if issues remain pending
+        if: always() && steps.remaining.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          ATTEMPT: ${{ github.event.inputs.attempt || '0' }}
+        run: |
+          attempt=$((ATTEMPT + 1))
+          if [[ "$attempt" -ge 60 ]]; then
+            echo "::warning::Max self-dispatch attempts (60) reached. Relying on cron fallback."
+            exit 0
+          fi
+          echo "Re-dispatching (attempt ${attempt}/360)..."
+          gh workflow run ci-poller.yml -R "$GITHUB_REPOSITORY" -f attempt="${attempt}"


### PR DESCRIPTION
## Problem

GitHub Actions cron is unreliable — \`*/5\` can drift to 30-40 minutes under load. For repos with fast CI (2-3 minutes), this means waiting 30+ minutes for the poller to notice CI passed.

## Solution

When the poller finds issues still pending, it self-dispatches via \`workflow_dispatch\` for a re-check. GHA startup latency (~30-60s) provides the natural gap between checks, giving effectively ~30-60 second polling intervals instead of 30-40 minutes.

The self-dispatch chain:
1. \`publish.yml\` \`waiting-for-ci\` triggers the poller (already implemented)
2. Poller checks CI status
3. If issues remain pending → self-dispatches for another check
4. If all resolved or failed → stops dispatching

Capped at 360 attempts (~3 hours) to prevent runaway chains. The cron remains as a safety net.

## Cost

- **Idle:** zero (no self-dispatch chain running)
- **Active:** ~30s per check, every ~30-60s via GHA startup latency
- **Concurrency group** prevents accumulation — at most 1 running + 1 queued