### PR TITLE
security: dual-write publish state file to safe location

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,11 +84,55 @@ jobs:
       - name: Set targets
         shell: bash
         if: fromJSON(steps.inputs.outputs.result).targets
-        run: >
-          jq -n --argjson
-          source '${{ toJSON(fromJSON(steps.inputs.outputs.result).targets) }}'
-          '[{($source[]): true }] | add | {"published": (. // {}) }'
-          > __repo__/${{ fromJSON(steps.inputs.outputs.result).path }}/.craft-publish-${{ fromJSON(steps.inputs.outputs.result).version }}.json
+        env:
+          CRAFT_PUBLISH_REPO: ${{ fromJSON(steps.inputs.outputs.result).repo }}
+          CRAFT_PUBLISH_PATH: ${{ fromJSON(steps.inputs.outputs.result).path }}
+          CRAFT_PUBLISH_VERSION: ${{ fromJSON(steps.inputs.outputs.result).version }}
+          CRAFT_PUBLISH_TARGETS_JSON: ${{ toJSON(fromJSON(steps.inputs.outputs.result).targets) }}
+        run: |
+          # Render the "already published" JSON once, reuse twice.
+          payload="$(jq -n --argjson source "$CRAFT_PUBLISH_TARGETS_JSON" '[{($source[]): true }] | add | {"published": (. // {}) }')"
+
+          # Write the NEW location Craft reads from (post
+          # getsentry/craft#795). Craft sees cwd
+          # `/github/workspace/__repo__/<path>` inside the container;
+          # the state dir is pinned to `$GITHUB_WORKSPACE/.craft-state`
+          # (mapped to `/github/workspace/.craft-state` in the
+          # container) via XDG_STATE_HOME. That path is outside
+          # __repo__/ so repo contents cannot pre-populate it.
+          #
+          # We hash the CONTAINER cwd (what Craft's Node process sees),
+          # not the runner host path. CRAFT_PUBLISH_PATH is either "."
+          # (root) or "./subdir/..." (monorepo); after bash `cd
+          # __repo__/<path>` and Node's process.cwd() canonicalisation,
+          # the cwd is `/github/workspace/__repo__` (root) or
+          # `/github/workspace/__repo__/subdir/...` (monorepo).
+          case "$CRAFT_PUBLISH_PATH" in
+            .|./) container_cwd="/github/workspace/__repo__" ;;
+            ./*) container_cwd="/github/workspace/__repo__/${CRAFT_PUBLISH_PATH#./}" ;;
+            *)   container_cwd="/github/workspace/__repo__/${CRAFT_PUBLISH_PATH}" ;;
+          esac
+          # Strip any trailing slash to match Node's canonicalisation.
+          container_cwd="${container_cwd%/}"
+          cwd_hash="$(printf %s "$container_cwd" | sha1sum | cut -c1-12)"
+          sanitise() { printf %s "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]\+/_/g; s/^_\+//; s/_\+$//'; }
+          owner_sanitised="$(sanitise getsentry)"
+          repo_sanitised="$(sanitise "$CRAFT_PUBLISH_REPO")"
+          version_sanitised="$(sanitise "$CRAFT_PUBLISH_VERSION")"
+          new_state_dir="$GITHUB_WORKSPACE/.craft-state/craft"
+          new_state_file="$new_state_dir/publish-state-${owner_sanitised}-${repo_sanitised}-${cwd_hash}-${version_sanitised}.json"
+          mkdir -p "$new_state_dir"
+          printf %s "$payload" > "$new_state_file"
+          echo "Wrote new-location state file: $new_state_file"
+
+          # Write the LEGACY location for the duration of the rollout so
+          # older Craft images (before the new-location support ships)
+          # keep working. Remove this block after Craft is released with
+          # the new-location read/write and we've confirmed a few
+          # publish runs succeed.
+          legacy_state_file="__repo__/${CRAFT_PUBLISH_PATH}/.craft-publish-${CRAFT_PUBLISH_VERSION}.json"
+          printf %s "$payload" > "$legacy_state_file"
+          echo "Wrote legacy-location state file: $legacy_state_file"
 
       - uses: docker://getsentry/craft:latest
         name: Publish using Craft
@@ -102,6 +146,10 @@ jobs:
             exec craft publish ${{ fromJSON(steps.inputs.outputs.result).version }}
             "
         env:
+          # Pin Craft's publish-state directory to a path outside
+          # __repo__/ so repo contents cannot pre-populate it. See the
+          # `Set targets` step above.
+          XDG_STATE_HOME: /github/workspace/.craft-state
           CRAFT_MERGE_TARGET: ${{ fromJSON(steps.inputs.outputs.result).merge_target }}
           CRAFT_LOG_LEVEL: ${{ vars.CRAFT_LOG_LEVEL || 'Info' }}
           CRAFT_DRY_RUN: ${{ fromJSON(steps.inputs.outputs.result).dry_run }}


### PR DESCRIPTION
## Summary

Writes `.craft-publish-<version>.json` to BOTH the legacy cwd location (for currently-deployed Craft images) and a new safe location at `$XDG_STATE_HOME/craft/publish-state-<owner>-<repo>-<sha1(cwd)[:12]>-<version>.json`. Ships alongside [getsentry/craft#797](https://github.com/getsentry/craft/pull/797), which moves Craft's read/write to the new location.

## Motivation

Craft's state file previously lived inside the project's cwd — which is inside the repository being published. Any committed file at that path (or any earlier CI step) could pre-populate the "already published" set and silently skip targets on publish, a pipeline-manipulation primitive. See the `security(publish): move publish-state file out of repo cwd` PR on getsentry/craft.

## Changes

### `.github/workflows/publish.yml` → `Set targets` step
- Render the payload once, reuse for both writes.
- Compute the new safe path: `$GITHUB_WORKSPACE/.craft-state/craft/publish-state-<owner>-<repo>-<sha1(container_cwd)[:12]>-<version>.json`. This is mounted into the Craft Docker container at `/github/workspace/.craft-state/craft/` — outside `__repo__/`, unreachable from repo contents.
- Write both locations. The legacy write will be removed in a follow-up once the new Craft release is in use.

### `Publish using Craft` step
- Set `XDG_STATE_HOME=/github/workspace/.craft-state` so Craft resolves the same new-location path.

## Filename determinism

The bash filename computation is designed to match `getPublishStateFilename()` in Craft exactly. Verified locally:

```
$ bash: printf %s '/github/workspace/__repo__/packages/browser' | sha1sum | cut -c1-12 → dbd7df897997
$ node: crypto.createHash('sha1').update('/github/workspace/__repo__/packages/browser').digest('hex').slice(0,12) → dbd7df897997
```

Both root-path (`.`) and monorepo (`./packages/foo`) inputs produce the same filename in bash and Node.

## Rollout

1. **This PR**: dual-write. Current Craft still reads the legacy location; new Craft (after #797) reads the new location. Both work with this workflow change.
2. [getsentry/craft#797](https://github.com/getsentry/craft/pull/797) + a Craft release + `:latest` bump.
3. Follow-up PR here: remove the legacy-location write.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Filename computation hand-simulated against both `.` and `./packages/foo` paths; matches Craft's output byte-for-byte.
- No secret exposure: all env vars used in the step are already present in `fromJSON(steps.inputs.outputs.result)`.

## Why not just move to the new location immediately?

Older Craft images (deployed via `docker://getsentry/craft:latest` today) expect the file at the legacy cwd path. Dropping the legacy write first would break publishes until the new Craft release rolls out to `:latest`, and would revert to breakage if anyone ever pinned to an older Craft tag. Dual-writes are zero-cost (a single extra `printf`) and make the transition safe.