### PR TITLE
security: remove legacy publish-state-file write

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,11 +188,11 @@ jobs:
           CRAFT_PUBLISH_VERSION: ${{ fromJSON(steps.inputs.outputs.result).version }}
           CRAFT_PUBLISH_TARGETS_JSON: ${{ toJSON(fromJSON(steps.inputs.outputs.result).targets) }}
         run: |
-          # Render the "already published" JSON once, reuse twice.
+          # Render the "already published" JSON.
           payload="$(jq -n --argjson source "$CRAFT_PUBLISH_TARGETS_JSON" '[{($source[]): true }] | add | {"published": (. // {}) }')"
 
-          # Write the NEW location Craft reads from (post
-          # getsentry/craft#795). Craft sees cwd
+          # Write the state file to the safe location Craft reads from
+          # (getsentry/craft#797, released in 2.26.0). Craft sees cwd
           # `/github/workspace/__repo__/<path>` inside the container;
           # the state dir is pinned to `$GITHUB_WORKSPACE/.craft-state`
           # (mapped to `/github/workspace/.craft-state` in the
@@ -217,20 +217,11 @@ jobs:
           owner_sanitised="$(sanitise getsentry)"
           repo_sanitised="$(sanitise "$CRAFT_PUBLISH_REPO")"
           version_sanitised="$(sanitise "$CRAFT_PUBLISH_VERSION")"
-          new_state_dir="$GITHUB_WORKSPACE/.craft-state/craft"
-          new_state_file="$new_state_dir/publish-state-${owner_sanitised}-${repo_sanitised}-${cwd_hash}-${version_sanitised}.json"
-          mkdir -p "$new_state_dir"
-          printf %s "$payload" > "$new_state_file"
-          echo "Wrote new-location state file: $new_state_file"
-
-          # Write the LEGACY location for the duration of the rollout so
-          # older Craft images (before the new-location support ships)
-          # keep working. Remove this block after Craft is released with
-          # the new-location read/write and we've confirmed a few
-          # publish runs succeed.
-          legacy_state_file="__repo__/${CRAFT_PUBLISH_PATH}/.craft-publish-${CRAFT_PUBLISH_VERSION}.json"
-          printf %s "$payload" > "$legacy_state_file"
-          echo "Wrote legacy-location state file: $legacy_state_file"
+          state_dir="$GITHUB_WORKSPACE/.craft-state/craft"
+          state_file="$state_dir/publish-state-${owner_sanitised}-${repo_sanitised}-${cwd_hash}-${version_sanitised}.json"
+          mkdir -p "$state_dir"
+          printf %s "$payload" > "$state_file"
+          echo "Wrote state file: $state_file"
 
       - uses: docker://getsentry/craft:latest
         name: Publish using Craft


### PR DESCRIPTION
## Summary

Drops the legacy-location write that #7886 added as a rollout aid for [getsentry/craft#797](https://github.com/getsentry/craft/pull/797). Craft 2.26.0 ships the new-location read/write and is now live on `getsentry/craft:latest`, so the dual-write is no longer needed.

## Context

- **#7886** (merged): started dual-writing the publish-state file to BOTH the legacy cwd location AND the safe `$XDG_STATE_HOME/craft/` location, so both old and new Craft images could find it during the rollout.
- **getsentry/craft#797** (merged, shipped in 2.26.0 at 2026-04-21T20:10Z): Craft reads/writes only the safe location.
- **This PR**: drop the legacy write. The new-write logic is unchanged from what #7886 already exercises in production.

## Verification

- Pulled the released `craft 2.26.0` binary, seeded a state file at the new location only, ran `craft publish 9.9.9` against a synthetic repo, and confirmed Craft logged `Found publish state file, resuming from there...` and honoured the `published` field to skip the target. End-to-end confirmation of the new-location read path with the 2.26.0 binary.
- Bash filename generation and Craft's Node filename generation produce byte-identical strings — verified earlier (in #7886 description) and unchanged here.
- YAML still parses (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Diff

8 insertions, 17 deletions: the legacy block is removed, comment updated to name the actual Craft PR (#797) that shipped the reader, and the remaining variables lose their `new_` prefix since there's only one location now.

## Rollback

If something regresses, revert this PR; #7886's dual-write code returns and both locations are written again. Old Craft images would still work off the legacy location.
