### PR TITLE
fix(ci-poller): link failed commit-status contexts to their CI runs

### DIFF
--- a/.github/workflows/ci-poller.yml
+++ b/.github/workflows/ci-poller.yml
@@ -239,8 +239,8 @@ jobs:
                 --add-label "ci-failed"
 
               failed_contexts=$(echo "$status_json" \
-                | jq -r '[.statuses[] | select(.state == "failure" or .state == "error")] | map(.context + " (" + .state + ")") | join(", ")')
-              comment_body="CI **commit status** checks failed for ${repo}@${version} (\`${sha:0:8}\`). Publishing is blocked."$'\n\n'"Failed status checks: ${failed_contexts}"$'\n\n'"[View check runs](https://github.com/${repo}/commit/${sha}/checks/)"$'\n\n'"Re-add the **accepted** label once CI is fixed to retry."
+                | jq -r '[.statuses[] | select(.state == "failure" or .state == "error")] | map(if .target_url and .target_url != "" and .target_url != "null" then "- [" + .context + "](" + .target_url + ") (" + .state + ")" else "- " + .context + " (" + .state + ")" end) | join("\n")')
+              comment_body="CI **commit status** checks failed for ${repo}@${version} (\`${sha:0:8}\`). Publishing is blocked."$'\n\n'"Failed status checks:"$'\n'"${failed_contexts}"$'\n\n'"[View check runs](https://github.com/${repo}/commit/${sha}/checks/)"$'\n\n'"Re-add the **accepted** label once CI is fixed to retry."
               gh issue comment "$number" -R "$GITHUB_REPOSITORY" --body "$comment_body"
             fi
           done


### PR DESCRIPTION
Related to https://github.com/getsentry/publish/pull/7825

The commit-status failure comment previously listed context names as plain text, pointing only at the generic /checks/ page which doesn't clearly surface the actual failing CI runs.

Now each failed context is rendered as a markdown link using the `target_url` from the GitHub commit status API, giving a direct clickable link to the failing CI run.

**Before:**
```
  Failed status checks: console/xbox (failure), console/switch (error)
```

**After:**
```
  Failed status checks:
  - [console/xbox](https://github.com/getsentry/sentry-xbox/actions/runs/27280300140) (failure)
  - [console/switch](https://github.com/getsentry/sentry-switch/actions/runs/27280298369) (error)
  - [manual-test/consolidate-compat-workflow](https://github.com/getsentry/sentry-switch/actions/runs/27284695950) (failure)
```

Ref: https://github.com/getsentry/publish/issues/8518#issuecomment-4671427176 

