### PR TITLE
ref(publish): Allow getsentry/javascript `v10` branch as a craft config source

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,6 +149,7 @@ jobs:
         # Note: Branches registered here MUST BE protected in the target repo!
         if: |
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-migr8' && fromJSON(steps.inputs.outputs.result).merge_target == 'tmp-merge-target' ||
+          fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v10' ||
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v9' ||
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v8' ||
           fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v7' ||


### PR DESCRIPTION
Adds our `v10` branch as an allowed branch from which we can use the `.craft.yml` config instead of pulling it from the main (`develop`) branch.

We need this merge target because going forward, JS SDK v10 releases will be cut from the `v10` branch. The craft config on the main branch has already diverged due to us stopping publishing of a few packages.

ref: https://develop.sentry.dev/sdk/getting-started/standards/release-versioning/#multiple-craft-configs