### PR TITLE
docs: fix run-on sentence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Automatic approvals are managed in the [`auto-approve.yml`](https://github.com/g
 
 ## Under the hood
 
-The system uses [Craft](https://github.com/getsentry/craft) under the hood to prepare and publish releases. It uses tokens from [Sentry Release Bot](https://github.com/apps/sentry-release-bot) is a GitHub App that is installed on all repos in `getsentry` with read and write access to code, PRs, and actions. We utilize the [create-github-app-token](https://github.com/actions/create-github-app-token) to generate a short live token in every action run, with `SENTRY_RELEASE_BOT_CLIENT_ID` and `SENTRY_RELEASE_BOT_PRIVATE_KEY` defined at the organization level.
+The system uses [Craft](https://github.com/getsentry/craft) under the hood to prepare and publish releases. It uses tokens from [Sentry Release Bot](https://github.com/apps/sentry-release-bot), which is a GitHub App that is installed on all repos in `getsentry` with read and write access to code, PRs, and actions. We utilize the [create-github-app-token](https://github.com/actions/create-github-app-token) to generate a short live token in every action run, with `SENTRY_RELEASE_BOT_CLIENT_ID` and `SENTRY_RELEASE_BOT_PRIVATE_KEY` defined at the organization level.
 
 This repo is read-only for everyone except for release managers. This is because all sensitive secrets such as admin-level GitHub access tokens or package repository publishing tokens (npm, PyPI, cargo, etc.) are defined in this repository as secrets and anyone with write access can create or trigger an arbitrary GitHub action workflow, exposing these secrets without any indication. See getsentry/sentry#21930 for an example.
 


### PR DESCRIPTION
The "Under the hood" section read:
"It uses tokens from Sentry Release Bot is a GitHub App that is installed..."

This is missing a connector between the two clauses. Added ", which" so it
reads: "...tokens from Sentry Release Bot, which is a GitHub App that is
installed on all repos in getsentry..."

Docs only, no functional changes.