### PR TITLE
docs: fix typo 'acces' -> 'access'

### DIFF
--- a/docs/key_rotation_vault_changes.md
+++ b/docs/key_rotation_vault_changes.md
@@ -24,7 +24,7 @@ Ways to improve credential management for releases:
 
 ### GitHub Actions in Separate Repo
 
-1. Centralize all release actions in a single, restricted-acces repo
+1. Centralize all release actions in a single, restricted-access repo
 2. Only add the bare-minimum personnel to this repo as admins (or with write access)
 3. Only expose the credentials/tokens to this repo
 4. At this stage, all releases access tokens are restricted to a few people


### PR DESCRIPTION
Small typo fix in docs/key_rotation_vault_changes.md:
"restricted-acces repo" -> "restricted-access repo"

Docs only, no functional changes.